### PR TITLE
PyDCS Export from 2.9.5.55300 (F4 Update)

### DIFF
--- a/dcs/countries.py
+++ b/dcs/countries.py
@@ -27,6 +27,7 @@ class Russia(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -123,6 +124,11 @@ class Russia(Country):
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
             S_75_ZIL = vehicles.Unarmed.S_75_ZIL
             TZ_22_KrAZ = vehicles.Unarmed.TZ_22_KrAZ
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -229,6 +235,7 @@ class Russia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -305,6 +312,7 @@ class Russia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -529,6 +537,7 @@ class Ukraine(Country):
             HL_B8M1 = vehicles.Artillery.HL_B8M1
             MLRS = vehicles.Artillery.MLRS
             M_109 = vehicles.Artillery.M_109
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Paratrooper_AKS_74 = vehicles.Infantry.Paratrooper_AKS_74
@@ -631,6 +640,11 @@ class Ukraine(Country):
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
             TZ_22_KrAZ = vehicles.Unarmed.TZ_22_KrAZ
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -728,6 +742,7 @@ class Ukraine(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -796,6 +811,7 @@ class Ukraine(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -918,6 +934,7 @@ class USA(Country):
             M12_GMC = vehicles.Artillery.M12_GMC
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M2A1_105 = vehicles.Artillery.M2A1_105
 
         class Infantry:
@@ -985,6 +1002,11 @@ class USA(Country):
             M30_CC = vehicles.Unarmed.M30_CC
             CCKW_353 = vehicles.Unarmed.CCKW_353
             Willys_MB = vehicles.Unarmed.Willys_MB
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -1104,6 +1126,7 @@ class USA(Country):
         C_101CC = planes.C_101CC
         JF_17 = planes.JF_17
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         I_16 = planes.I_16
         M_2000C = planes.M_2000C
         MB_339A = planes.MB_339A
@@ -1182,6 +1205,7 @@ class USA(Country):
         Plane.C_101CC,
         Plane.JF_17,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.I_16,
         Plane.M_2000C,
         Plane.MB_339A,
@@ -1402,6 +1426,7 @@ class Turkey(Country):
             T155_Firtina = vehicles.Artillery.T155_Firtina
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Hawk_sr = vehicles.AirDefence.Hawk_sr
@@ -1441,6 +1466,11 @@ class Turkey(Country):
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             Predator_GCS = vehicles.Unarmed.Predator_GCS
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -1515,6 +1545,7 @@ class Turkey(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -1571,6 +1602,7 @@ class Turkey(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -1769,6 +1801,7 @@ class UK(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -1813,6 +1846,11 @@ class UK(Country):
             Willys_MB = vehicles.Unarmed.Willys_MB
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
             Land_Rover_109_S3 = vehicles.Unarmed.Land_Rover_109_S3
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             CCKW_353 = vehicles.Unarmed.CCKW_353
@@ -1894,6 +1932,7 @@ class UK(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -1948,6 +1987,7 @@ class UK(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -2149,6 +2189,7 @@ class France(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -2188,6 +2229,11 @@ class France(Country):
             Predator_GCS = vehicles.Unarmed.Predator_GCS
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
             CCKW_353 = vehicles.Unarmed.CCKW_353
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -2268,6 +2314,7 @@ class France(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -2327,6 +2374,7 @@ class France(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -2524,6 +2572,7 @@ class Germany(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -2625,6 +2674,11 @@ class Germany(Country):
             Ural_4320T = vehicles.Unarmed.Ural_4320T
             ZIL_131_KUNG = vehicles.Unarmed.ZIL_131_KUNG
             ATZ_5 = vehicles.Unarmed.ATZ_5
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Kubelwagen_82 = vehicles.Unarmed.Kubelwagen_82
@@ -2723,6 +2777,7 @@ class Germany(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -2780,6 +2835,7 @@ class Germany(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -2967,6 +3023,7 @@ class USAFAggressors(Country):
     class Vehicle:
 
         class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -3123,6 +3180,11 @@ class USAFAggressors(Country):
             Fire_control = vehicles.Fortification.Fire_control
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -3306,6 +3368,7 @@ class USAFAggressors(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -3433,6 +3496,7 @@ class USAFAggressors(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -3773,6 +3837,7 @@ class Canada(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -3805,6 +3870,11 @@ class Canada(Country):
             M_818 = vehicles.Unarmed.M_818
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -3888,6 +3958,7 @@ class Canada(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -3938,6 +4009,7 @@ class Canada(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -4129,6 +4201,7 @@ class Spain(Country):
             X_2B11_mortar = vehicles.Artillery.X_2B11_mortar
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Hawk_sr = vehicles.AirDefence.Hawk_sr
@@ -4169,6 +4242,11 @@ class Spain(Country):
             M_818 = vehicles.Unarmed.M_818
             Predator_GCS = vehicles.Unarmed.Predator_GCS
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -4238,6 +4316,7 @@ class Spain(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -4295,6 +4374,7 @@ class Spain(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -4493,6 +4573,7 @@ class TheNetherlands(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -4543,6 +4624,11 @@ class TheNetherlands(Country):
             M_818 = vehicles.Unarmed.M_818
             Predator_GCS = vehicles.Unarmed.Predator_GCS
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -4628,6 +4714,7 @@ class TheNetherlands(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -4682,6 +4769,7 @@ class TheNetherlands(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -4880,6 +4968,7 @@ class Belgium(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -4918,6 +5007,11 @@ class Belgium(Country):
         class Unarmed:
             Hummer = vehicles.Unarmed.Hummer
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -4994,6 +5088,7 @@ class Belgium(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -5046,6 +5141,7 @@ class Belgium(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -5240,6 +5336,7 @@ class Norway(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Hawk_sr = vehicles.AirDefence.Hawk_sr
@@ -5272,6 +5369,11 @@ class Norway(Country):
         class Unarmed:
             Hummer = vehicles.Unarmed.Hummer
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -5338,6 +5440,7 @@ class Norway(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -5390,6 +5493,7 @@ class Norway(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -5581,6 +5685,7 @@ class Denmark(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Hawk_sr = vehicles.AirDefence.Hawk_sr
@@ -5612,6 +5717,11 @@ class Denmark(Country):
         class Unarmed:
             Hummer = vehicles.Unarmed.Hummer
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -5679,6 +5789,7 @@ class Denmark(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -5731,6 +5842,7 @@ class Denmark(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -5920,6 +6032,7 @@ class Israel(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             M1097_Avenger = vehicles.AirDefence.M1097_Avenger
@@ -5959,6 +6072,11 @@ class Israel(Country):
         class Unarmed:
             Hummer = vehicles.Unarmed.Hummer
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -6037,6 +6155,7 @@ class Israel(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -6093,6 +6212,7 @@ class Israel(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -6296,6 +6416,7 @@ class Georgia(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4_GRG = vehicles.Infantry.Soldier_M4_GRG
@@ -6373,6 +6494,11 @@ class Georgia(Country):
             ATZ_5 = vehicles.Unarmed.ATZ_5
             S_75_ZIL = vehicles.Unarmed.S_75_ZIL
             TZ_22_KrAZ = vehicles.Unarmed.TZ_22_KrAZ
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -6445,6 +6571,7 @@ class Georgia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -6497,6 +6624,7 @@ class Georgia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -6696,6 +6824,7 @@ class Insurgents(Country):
             X_2B11_mortar = vehicles.Artillery.X_2B11_mortar
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_AK = vehicles.Infantry.Soldier_AK
@@ -6745,6 +6874,11 @@ class Insurgents(Country):
             ZiL_131_APA_80 = vehicles.Unarmed.ZiL_131_APA_80
             ZIL_131_KUNG = vehicles.Unarmed.ZIL_131_KUNG
             ATZ_5 = vehicles.Unarmed.ATZ_5
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -6804,6 +6938,7 @@ class Insurgents(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -6850,6 +6985,7 @@ class Insurgents(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -6964,6 +7100,7 @@ class Abkhazia(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK_Ins = vehicles.Infantry.Infantry_AK_Ins
@@ -7024,6 +7161,11 @@ class Abkhazia(Country):
             ZIL_131_KUNG = vehicles.Unarmed.ZIL_131_KUNG
             ZIL_4331 = vehicles.Unarmed.ZIL_4331
             ATZ_5 = vehicles.Unarmed.ATZ_5
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -7092,6 +7234,7 @@ class Abkhazia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -7142,6 +7285,7 @@ class Abkhazia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -7255,6 +7399,7 @@ class SouthOssetia(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK_Ins = vehicles.Infantry.Infantry_AK_Ins
@@ -7308,6 +7453,11 @@ class SouthOssetia(Country):
             ZIL_131_KUNG = vehicles.Unarmed.ZIL_131_KUNG
             ZIL_4331 = vehicles.Unarmed.ZIL_4331
             ATZ_5 = vehicles.Unarmed.ATZ_5
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -7368,6 +7518,7 @@ class SouthOssetia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -7413,6 +7564,7 @@ class SouthOssetia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -7522,6 +7674,7 @@ class Italy(Country):
             X_2B11_mortar = vehicles.Artillery.X_2B11_mortar
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             JTAC = vehicles.Infantry.JTAC
@@ -7558,6 +7711,11 @@ class Italy(Country):
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             Predator_GCS = vehicles.Unarmed.Predator_GCS
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -7628,6 +7786,7 @@ class Italy(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -7684,6 +7843,7 @@ class Italy(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -7873,6 +8033,7 @@ class Australia(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -7911,6 +8072,11 @@ class Australia(Country):
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
             Land_Rover_109_S3 = vehicles.Unarmed.Land_Rover_109_S3
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -7992,6 +8158,7 @@ class Australia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -8043,6 +8210,7 @@ class Australia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -8237,6 +8405,7 @@ class Switzerland(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Soldier_stinger = vehicles.AirDefence.Soldier_stinger
@@ -8260,6 +8429,11 @@ class Switzerland(Country):
 
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -8322,6 +8496,7 @@ class Switzerland(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
@@ -8369,6 +8544,7 @@ class Switzerland(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
@@ -8549,6 +8725,7 @@ class Austria(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -8567,6 +8744,11 @@ class Austria(Country):
 
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -8627,6 +8809,7 @@ class Austria(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -8673,6 +8856,7 @@ class Austria(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -8867,6 +9051,7 @@ class Belarus(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -8953,6 +9138,11 @@ class Belarus(Country):
             ZIL_135 = vehicles.Unarmed.ZIL_135
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
             TZ_22_KrAZ = vehicles.Unarmed.TZ_22_KrAZ
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -9035,6 +9225,7 @@ class Belarus(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -9092,6 +9283,7 @@ class Belarus(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -9200,6 +9392,7 @@ class Bulgaria(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -9273,6 +9466,11 @@ class Bulgaria(Country):
             VAZ_Car = vehicles.Unarmed.VAZ_Car
             ZIL_135 = vehicles.Unarmed.ZIL_135
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -9367,6 +9565,7 @@ class Bulgaria(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -9421,6 +9620,7 @@ class Bulgaria(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -9611,6 +9811,7 @@ class CzechRepublic(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -9653,6 +9854,11 @@ class CzechRepublic(Country):
             UAZ_469 = vehicles.Unarmed.UAZ_469
             Trolley_bus = vehicles.Unarmed.Trolley_bus
             VAZ_Car = vehicles.Unarmed.VAZ_Car
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -9734,6 +9940,7 @@ class CzechRepublic(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -9785,6 +9992,7 @@ class CzechRepublic(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -9979,6 +10187,7 @@ class China(Country):
             PLZ05 = vehicles.Artillery.PLZ05
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Tor_9A331 = vehicles.AirDefence.Tor_9A331
@@ -10023,6 +10232,11 @@ class China(Country):
             Ural_375 = vehicles.Unarmed.Ural_375
             Tigr_233036 = vehicles.Unarmed.Tigr_233036
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -10099,6 +10313,7 @@ class China(Country):
         H_6J = planes.H_6J
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -10156,6 +10371,7 @@ class China(Country):
         Plane.H_6J,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -10268,6 +10484,7 @@ class Croatia(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -10290,6 +10507,11 @@ class Croatia(Country):
 
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -10346,6 +10568,7 @@ class Croatia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -10392,6 +10615,7 @@ class Croatia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -10584,6 +10808,7 @@ class Egypt(Country):
             MLRS = vehicles.Artillery.MLRS
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -10663,6 +10888,11 @@ class Egypt(Country):
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
             ZIL_135 = vehicles.Unarmed.ZIL_135
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -10741,6 +10971,7 @@ class Egypt(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -10794,6 +11025,7 @@ class Egypt(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -10995,6 +11227,7 @@ class Finland(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -11056,6 +11289,11 @@ class Finland(Country):
             UAZ_469 = vehicles.Unarmed.UAZ_469
             Trolley_bus = vehicles.Unarmed.Trolley_bus
             VAZ_Car = vehicles.Unarmed.VAZ_Car
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -11141,6 +11379,7 @@ class Finland(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -11186,6 +11425,7 @@ class Finland(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -11371,6 +11611,7 @@ class Greece(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4 = vehicles.Infantry.Soldier_M4
@@ -11424,6 +11665,11 @@ class Greece(Country):
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
             Trolley_bus = vehicles.Unarmed.Trolley_bus
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -11498,6 +11744,7 @@ class Greece(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -11552,6 +11799,7 @@ class Greece(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -11752,6 +12000,7 @@ class Hungary(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -11817,6 +12066,11 @@ class Hungary(Country):
             MAZ_6303 = vehicles.Unarmed.MAZ_6303
             Trolley_bus = vehicles.Unarmed.Trolley_bus
             VAZ_Car = vehicles.Unarmed.VAZ_Car
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -11906,6 +12160,7 @@ class Hungary(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -11956,6 +12211,7 @@ class Hungary(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -12146,6 +12402,7 @@ class India(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -12189,6 +12446,11 @@ class India(Country):
             Predator_GCS = vehicles.Unarmed.Predator_GCS
             Predator_TrojanSpirit = vehicles.Unarmed.Predator_TrojanSpirit
             KrAZ6322 = vehicles.Unarmed.KrAZ6322
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -12261,6 +12523,7 @@ class India(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -12315,6 +12578,7 @@ class India(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -12511,6 +12775,7 @@ class Iran(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK_Ins = vehicles.Infantry.Infantry_AK_Ins
@@ -12573,6 +12838,11 @@ class Iran(Country):
             Ural_375 = vehicles.Unarmed.Ural_375
             KrAZ6322 = vehicles.Unarmed.KrAZ6322
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -12654,6 +12924,7 @@ class Iran(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_14B = planes.F_14B
         F_14A_135_GR = planes.F_14A_135_GR
         F_A_18A = planes.F_A_18A
@@ -12712,6 +12983,7 @@ class Iran(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_14B,
         Plane.F_14A_135_GR,
         Plane.F_A_18A,
@@ -12915,6 +13187,7 @@ class Iraq(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -12966,6 +13239,11 @@ class Iraq(Country):
             Hummer = vehicles.Unarmed.Hummer
             KrAZ6322 = vehicles.Unarmed.KrAZ6322
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -13048,6 +13326,7 @@ class Iraq(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -13103,6 +13382,7 @@ class Iraq(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -13288,6 +13568,7 @@ class Japan(Country):
         class Artillery:
             MLRS = vehicles.Artillery.MLRS
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
+            L118_Unit = vehicles.Artillery.L118_Unit
             HL_B8M1 = vehicles.Artillery.HL_B8M1
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             Wespe124 = vehicles.Artillery.Wespe124
@@ -13341,6 +13622,11 @@ class Japan(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -13417,6 +13703,7 @@ class Japan(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -13465,6 +13752,7 @@ class Japan(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -13669,6 +13957,7 @@ class Kazakhstan(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Paratrooper_RPG_16 = vehicles.Infantry.Paratrooper_RPG_16
@@ -13759,6 +14048,11 @@ class Kazakhstan(Country):
             Tigr_233036 = vehicles.Unarmed.Tigr_233036
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
             TZ_22_KrAZ = vehicles.Unarmed.TZ_22_KrAZ
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -13843,6 +14137,7 @@ class Kazakhstan(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -13901,6 +14196,7 @@ class Kazakhstan(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -14093,6 +14389,7 @@ class NorthKorea(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -14126,6 +14423,11 @@ class NorthKorea(Country):
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -14194,6 +14496,7 @@ class NorthKorea(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -14242,6 +14545,7 @@ class NorthKorea(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -14429,6 +14733,7 @@ class Pakistan(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -14465,6 +14770,11 @@ class Pakistan(Country):
 
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -14534,6 +14844,7 @@ class Pakistan(Country):
         C_101CC = planes.C_101CC
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -14587,6 +14898,7 @@ class Pakistan(Country):
         Plane.C_101CC,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -14776,6 +15088,7 @@ class Poland(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -14827,6 +15140,11 @@ class Poland(Country):
             Trolley_bus = vehicles.Unarmed.Trolley_bus
             VAZ_Car = vehicles.Unarmed.VAZ_Car
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -14925,6 +15243,7 @@ class Poland(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -14981,6 +15300,7 @@ class Poland(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -15171,6 +15491,7 @@ class Romania(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -15231,6 +15552,11 @@ class Romania(Country):
             Trolley_bus = vehicles.Unarmed.Trolley_bus
             VAZ_Car = vehicles.Unarmed.VAZ_Car
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -15319,6 +15645,7 @@ class Romania(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -15370,6 +15697,7 @@ class Romania(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -15563,6 +15891,7 @@ class SaudiArabia(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Soldier_stinger = vehicles.AirDefence.Soldier_stinger
@@ -15601,6 +15930,11 @@ class SaudiArabia(Country):
             M_818 = vehicles.Unarmed.M_818
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -15672,6 +16006,7 @@ class SaudiArabia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
         FA_18C_hornet = planes.FA_18C_hornet
@@ -15724,6 +16059,7 @@ class SaudiArabia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_A_18A,
         Plane.F_A_18C,
         Plane.FA_18C_hornet,
@@ -15921,6 +16257,7 @@ class Serbia(Country):
             X_2B11_mortar = vehicles.Artillery.X_2B11_mortar
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Paratrooper_RPG_16 = vehicles.Infantry.Paratrooper_RPG_16
@@ -15979,6 +16316,11 @@ class Serbia(Country):
             KAMAZ_Truck = vehicles.Unarmed.KAMAZ_Truck
             MAZ_6303 = vehicles.Unarmed.MAZ_6303
             Trolley_bus = vehicles.Unarmed.Trolley_bus
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -16044,6 +16386,7 @@ class Serbia(Country):
         WingLoong_I = planes.WingLoong_I
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -16094,6 +16437,7 @@ class Serbia(Country):
         Plane.WingLoong_I,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -16283,6 +16627,7 @@ class Slovakia(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             SNR_75V = vehicles.AirDefence.SNR_75V
@@ -16327,6 +16672,11 @@ class Slovakia(Country):
             Trolley_bus = vehicles.Unarmed.Trolley_bus
             VAZ_Car = vehicles.Unarmed.VAZ_Car
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -16393,6 +16743,7 @@ class Slovakia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -16443,6 +16794,7 @@ class Slovakia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -16630,6 +16982,7 @@ class SouthKorea(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -16669,6 +17022,11 @@ class SouthKorea(Country):
             M_818 = vehicles.Unarmed.M_818
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -16738,6 +17096,7 @@ class SouthKorea(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
         FA_18C_hornet = planes.FA_18C_hornet
@@ -16790,6 +17149,7 @@ class SouthKorea(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_A_18A,
         Plane.F_A_18C,
         Plane.FA_18C_hornet,
@@ -16974,6 +17334,7 @@ class Sweden(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -16998,6 +17359,11 @@ class Sweden(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -17059,6 +17425,7 @@ class Sweden(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -17108,6 +17475,7 @@ class Sweden(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -17297,6 +17665,7 @@ class Syria(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_RPG = vehicles.Infantry.Soldier_RPG
@@ -17365,6 +17734,11 @@ class Syria(Country):
             ATZ_5 = vehicles.Unarmed.ATZ_5
             ATMZ_5 = vehicles.Unarmed.ATMZ_5
             ATZ_10 = vehicles.Unarmed.ATZ_10
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -17437,6 +17811,7 @@ class Syria(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -17488,6 +17863,7 @@ class Syria(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -17677,6 +18053,7 @@ class Yemen(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -17715,6 +18092,11 @@ class Yemen(Country):
             Hummer = vehicles.Unarmed.Hummer
             KrAZ6322 = vehicles.Unarmed.KrAZ6322
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -17783,6 +18165,7 @@ class Yemen(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -17832,6 +18215,7 @@ class Yemen(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -18024,6 +18408,7 @@ class Vietnam(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -18071,6 +18456,11 @@ class Vietnam(Country):
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -18146,6 +18536,7 @@ class Vietnam(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -18197,6 +18588,7 @@ class Vietnam(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -18386,6 +18778,7 @@ class Venezuela(Country):
             X_2B11_mortar = vehicles.Artillery.X_2B11_mortar
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             ZU_23_Emplacement = vehicles.AirDefence.ZU_23_Emplacement
@@ -18426,6 +18819,11 @@ class Venezuela(Country):
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -18487,6 +18885,7 @@ class Venezuela(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -18535,6 +18934,7 @@ class Venezuela(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -18721,6 +19121,7 @@ class Tunisia(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             M48_Chaparral = vehicles.AirDefence.M48_Chaparral
@@ -18740,6 +19141,11 @@ class Tunisia(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -18798,6 +19204,7 @@ class Tunisia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
         FA_18C_hornet = planes.FA_18C_hornet
@@ -18844,6 +19251,7 @@ class Tunisia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_A_18A,
         Plane.F_A_18C,
         Plane.FA_18C_hornet,
@@ -19025,6 +19433,7 @@ class Thailand(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -19054,6 +19463,11 @@ class Thailand(Country):
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
             KrAZ6322 = vehicles.Unarmed.KrAZ6322
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -19117,6 +19531,7 @@ class Thailand(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
         FA_18C_hornet = planes.FA_18C_hornet
@@ -19166,6 +19581,7 @@ class Thailand(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_A_18A,
         Plane.F_A_18C,
         Plane.FA_18C_hornet,
@@ -19356,6 +19772,7 @@ class Sudan(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -19384,6 +19801,11 @@ class Sudan(Country):
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -19450,6 +19872,7 @@ class Sudan(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -19500,6 +19923,7 @@ class Sudan(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -19681,6 +20105,9 @@ class Philippines(Country):
 
     class Vehicle:
 
+        class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
+
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
 
@@ -19697,6 +20124,11 @@ class Philippines(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -19756,6 +20188,7 @@ class Philippines(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
         FA_18C_hornet = planes.FA_18C_hornet
@@ -19804,6 +20237,7 @@ class Philippines(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_A_18A,
         Plane.F_A_18C,
         Plane.FA_18C_hornet,
@@ -19988,6 +20422,7 @@ class Morocco(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Hawk_tr = vehicles.AirDefence.Hawk_tr
@@ -20025,6 +20460,11 @@ class Morocco(Country):
             Hummer = vehicles.Unarmed.Hummer
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -20088,6 +20528,7 @@ class Morocco(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -20138,6 +20579,7 @@ class Morocco(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -20326,6 +20768,7 @@ class Mexico(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -20347,6 +20790,11 @@ class Mexico(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -20405,6 +20853,7 @@ class Mexico(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -20452,6 +20901,7 @@ class Mexico(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -20642,6 +21092,7 @@ class Malaysia(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -20668,6 +21119,11 @@ class Malaysia(Country):
 
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -20728,6 +21184,7 @@ class Malaysia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -20775,6 +21232,7 @@ class Malaysia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -20964,6 +21422,7 @@ class Libya(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -21007,6 +21466,11 @@ class Libya(Country):
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -21070,6 +21534,7 @@ class Libya(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -21120,6 +21585,7 @@ class Libya(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -21306,6 +21772,7 @@ class Jordan(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -21343,6 +21810,11 @@ class Jordan(Country):
             Hummer = vehicles.Unarmed.Hummer
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -21407,6 +21879,7 @@ class Jordan(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -21457,6 +21930,7 @@ class Jordan(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -21650,6 +22124,7 @@ class Indonesia(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4 = vehicles.Infantry.Soldier_M4
@@ -21696,6 +22171,11 @@ class Indonesia(Country):
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
             Tigr_233036 = vehicles.Unarmed.Tigr_233036
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -21770,6 +22250,7 @@ class Indonesia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -21823,6 +22304,7 @@ class Indonesia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -22011,6 +22493,7 @@ class Honduras(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Tt_ZU_23 = vehicles.AirDefence.Tt_ZU_23
@@ -22029,6 +22512,11 @@ class Honduras(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -22086,6 +22574,7 @@ class Honduras(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -22132,6 +22621,7 @@ class Honduras(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -22319,6 +22809,7 @@ class Ethiopia(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             P_19_s_125_sr = vehicles.AirDefence.P_19_s_125_sr
@@ -22352,6 +22843,11 @@ class Ethiopia(Country):
         class Unarmed:
             Ural_375 = vehicles.Unarmed.Ural_375
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -22420,6 +22916,7 @@ class Ethiopia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
         FA_18C_hornet = planes.FA_18C_hornet
@@ -22469,6 +22966,7 @@ class Ethiopia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_A_18A,
         Plane.F_A_18C,
         Plane.FA_18C_hornet,
@@ -22650,6 +23148,7 @@ class Chile(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Soldier_stinger = vehicles.AirDefence.Soldier_stinger
@@ -22679,6 +23178,11 @@ class Chile(Country):
         class Unarmed:
             Hummer = vehicles.Unarmed.Hummer
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -22747,6 +23251,7 @@ class Chile(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -22799,6 +23304,7 @@ class Chile(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -22991,6 +23497,7 @@ class Brazil(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4 = vehicles.Infantry.Soldier_M4
@@ -23027,6 +23534,11 @@ class Brazil(Country):
             M_818 = vehicles.Unarmed.M_818
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -23089,6 +23601,7 @@ class Brazil(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -23136,6 +23649,7 @@ class Brazil(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -23325,6 +23839,7 @@ class Bahrain(Country):
             MLRS_FDDM = vehicles.Artillery.MLRS_FDDM
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4 = vehicles.Infantry.Soldier_M4
@@ -23359,6 +23874,11 @@ class Bahrain(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -23418,6 +23938,7 @@ class Bahrain(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_86F_Sabre = planes.F_86F_Sabre
         F_A_18A = planes.F_A_18A
         F_A_18C = planes.F_A_18C
@@ -23463,6 +23984,7 @@ class Bahrain(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_86F_Sabre,
         Plane.F_A_18A,
         Plane.F_A_18C,
@@ -23645,6 +24167,7 @@ class ThirdReich(Country):
     class Vehicle:
 
         class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -23678,6 +24201,11 @@ class ThirdReich(Country):
             Fire_control = vehicles.Fortification.Fire_control
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -23746,6 +24274,7 @@ class ThirdReich(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -23792,6 +24321,7 @@ class ThirdReich(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -23978,6 +24508,7 @@ class Yugoslavia(Country):
         class Artillery:
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -24014,6 +24545,11 @@ class Yugoslavia(Country):
             Ural_375 = vehicles.Unarmed.Ural_375
             VAZ_Car = vehicles.Unarmed.VAZ_Car
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Bedford_MWD = vehicles.Unarmed.Bedford_MWD
@@ -24089,6 +24625,7 @@ class Yugoslavia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -24137,6 +24674,7 @@ class Yugoslavia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -24249,6 +24787,7 @@ class USSR(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Uragan_BM_27 = vehicles.Artillery.Uragan_BM_27
             SpGH_Dana = vehicles.Artillery.SpGH_Dana
+            L118_Unit = vehicles.Artillery.L118_Unit
             M12_GMC = vehicles.Artillery.M12_GMC
             M2A1_105 = vehicles.Artillery.M2A1_105
 
@@ -24345,6 +24884,11 @@ class USSR(Country):
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
             S_75_ZIL = vehicles.Unarmed.S_75_ZIL
             TZ_22_KrAZ = vehicles.Unarmed.TZ_22_KrAZ
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             AA8 = vehicles.Unarmed.AA8
@@ -24459,6 +25003,7 @@ class USSR(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -24530,6 +25075,7 @@ class USSR(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -24644,6 +25190,7 @@ class ItalianSocialRepublic(Country):
     class Vehicle:
 
         class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -24677,6 +25224,11 @@ class ItalianSocialRepublic(Country):
             Fire_control = vehicles.Fortification.Fire_control
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -24744,6 +25296,7 @@ class ItalianSocialRepublic(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -24789,6 +25342,7 @@ class ItalianSocialRepublic(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -24982,6 +25536,7 @@ class Algeria(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -25074,6 +25629,11 @@ class Algeria(Country):
             ATZ_5 = vehicles.Unarmed.ATZ_5
             ZIL_135 = vehicles.Unarmed.ZIL_135
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -25155,6 +25715,7 @@ class Algeria(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -25217,6 +25778,7 @@ class Algeria(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -25422,6 +25984,7 @@ class Kuwait(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Hawk_tr = vehicles.AirDefence.Hawk_tr
@@ -25457,6 +26020,11 @@ class Kuwait(Country):
             Hummer = vehicles.Unarmed.Hummer
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -25521,6 +26089,7 @@ class Kuwait(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -25569,6 +26138,7 @@ class Kuwait(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -25755,6 +26325,7 @@ class Qatar(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -25785,6 +26356,11 @@ class Qatar(Country):
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -25842,6 +26418,7 @@ class Qatar(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -25891,6 +26468,7 @@ class Qatar(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -26078,6 +26656,7 @@ class Oman(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             ZU_23_Emplacement = vehicles.AirDefence.ZU_23_Emplacement
@@ -26119,6 +26698,11 @@ class Oman(Country):
             M_818 = vehicles.Unarmed.M_818
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -26184,6 +26768,7 @@ class Oman(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -26232,6 +26817,7 @@ class Oman(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -26423,6 +27009,7 @@ class UnitedArabEmirates(Country):
             Smerch_HE = vehicles.Artillery.Smerch_HE
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Patriot_str = vehicles.AirDefence.Patriot_str
@@ -26460,6 +27047,11 @@ class UnitedArabEmirates(Country):
             M_818 = vehicles.Unarmed.M_818
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
@@ -26528,6 +27120,7 @@ class UnitedArabEmirates(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -26578,6 +27171,7 @@ class UnitedArabEmirates(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -26771,6 +27365,7 @@ class SouthAfrica(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             ZU_23_Emplacement = vehicles.AirDefence.ZU_23_Emplacement
@@ -26792,6 +27387,11 @@ class SouthAfrica(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Land_Rover_109_S3 = vehicles.Unarmed.Land_Rover_109_S3
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -26850,6 +27450,7 @@ class SouthAfrica(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -26899,6 +27500,7 @@ class SouthAfrica(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -27088,6 +27690,7 @@ class Cuba(Country):
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Paratrooper_RPG_16 = vehicles.Infantry.Paratrooper_RPG_16
@@ -27146,6 +27749,11 @@ class Cuba(Country):
             ZIL_131_KUNG = vehicles.Unarmed.ZIL_131_KUNG
             Ural_4320_APA_5D = vehicles.Unarmed.Ural_4320_APA_5D
             ZIL_135 = vehicles.Unarmed.ZIL_135
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -27223,6 +27831,7 @@ class Cuba(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -27279,6 +27888,7 @@ class Cuba(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -27469,6 +28079,7 @@ class Portugal(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             M48_Chaparral = vehicles.AirDefence.M48_Chaparral
@@ -27492,6 +28103,11 @@ class Portugal(Country):
 
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -27558,6 +28174,7 @@ class Portugal(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -27609,6 +28226,7 @@ class Portugal(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -27793,6 +28411,7 @@ class GDR(Country):
             Grad_URAL = vehicles.Artillery.Grad_URAL
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             SAU_Akatsia = vehicles.Artillery.SAU_Akatsia
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -27856,6 +28475,11 @@ class GDR(Country):
             ZIL_135 = vehicles.Unarmed.ZIL_135
             ATZ_60_Maz = vehicles.Unarmed.ATZ_60_Maz
             S_75_ZIL = vehicles.Unarmed.S_75_ZIL
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -27920,6 +28544,7 @@ class GDR(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -27969,6 +28594,7 @@ class GDR(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -28153,6 +28779,7 @@ class Lebanon(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -28191,6 +28818,11 @@ class Lebanon(Country):
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
             Land_Rover_109_S3 = vehicles.Unarmed.Land_Rover_109_S3
             M_818 = vehicles.Unarmed.M_818
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -28253,6 +28885,7 @@ class Lebanon(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -28300,6 +28933,7 @@ class Lebanon(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -28485,6 +29119,7 @@ class CombinedJointTaskForcesBlue(Country):
     class Vehicle:
 
         class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -28641,6 +29276,11 @@ class CombinedJointTaskForcesBlue(Country):
             Fire_control = vehicles.Fortification.Fire_control
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -28823,6 +29463,7 @@ class CombinedJointTaskForcesBlue(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -28950,6 +29591,7 @@ class CombinedJointTaskForcesBlue(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -29288,6 +29930,7 @@ class CombinedJointTaskForcesRed(Country):
     class Vehicle:
 
         class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -29444,6 +30087,11 @@ class CombinedJointTaskForcesRed(Country):
             Fire_control = vehicles.Fortification.Fire_control
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -29626,6 +30274,7 @@ class CombinedJointTaskForcesRed(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -29753,6 +30402,7 @@ class CombinedJointTaskForcesRed(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -30091,6 +30741,7 @@ class UnitedNationsPeacekeepers(Country):
     class Vehicle:
 
         class Artillery:
+            L118_Unit = vehicles.Artillery.L118_Unit
             Wespe124 = vehicles.Artillery.Wespe124
             Pak40 = vehicles.Artillery.Pak40
             LeFH_18_40_105 = vehicles.Artillery.LeFH_18_40_105
@@ -30247,6 +30898,11 @@ class UnitedNationsPeacekeepers(Country):
             Fire_control = vehicles.Fortification.Fire_control
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
             Blitz_36_6700A = vehicles.Unarmed.Blitz_36_6700A
@@ -30429,6 +31085,7 @@ class UnitedNationsPeacekeepers(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -30556,6 +31213,7 @@ class UnitedNationsPeacekeepers(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -30896,6 +31554,7 @@ class Argentina(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -30918,6 +31577,11 @@ class Argentina(Country):
             Hummer = vehicles.Unarmed.Hummer
             M_818 = vehicles.Unarmed.M_818
             Trolley_bus = vehicles.Unarmed.Trolley_bus
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -30979,6 +31643,7 @@ class Argentina(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -31026,6 +31691,7 @@ class Argentina(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -31218,6 +31884,7 @@ class Cyprus(Country):
             SpGH_Dana = vehicles.Artillery.SpGH_Dana
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4 = vehicles.Infantry.Soldier_M4
@@ -31258,6 +31925,11 @@ class Cyprus(Country):
             KAMAZ_Truck = vehicles.Unarmed.KAMAZ_Truck
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -31313,6 +31985,7 @@ class Cyprus(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -31359,6 +32032,7 @@ class Cyprus(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -31546,6 +32220,7 @@ class Slovenia(Country):
             SAU_Gvozdika = vehicles.Artillery.SAU_Gvozdika
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M249 = vehicles.Infantry.Soldier_M249
@@ -31575,6 +32250,11 @@ class Slovenia(Country):
             HEMTT_TFFT = vehicles.Unarmed.HEMTT_TFFT
             Hummer = vehicles.Unarmed.Hummer
             M978_HEMTT_Tanker = vehicles.Unarmed.M978_HEMTT_Tanker
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -31635,6 +32315,7 @@ class Slovenia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -31682,6 +32363,7 @@ class Slovenia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -31871,6 +32553,7 @@ class Bolivia(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Soldier_M4 = vehicles.Infantry.Soldier_M4
@@ -31898,6 +32581,11 @@ class Bolivia(Country):
             M_818 = vehicles.Unarmed.M_818
             ZiL_131_APA_80 = vehicles.Unarmed.ZiL_131_APA_80
             ZIL_131_KUNG = vehicles.Unarmed.ZIL_131_KUNG
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -31961,6 +32649,7 @@ class Bolivia(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -32010,6 +32699,7 @@ class Bolivia(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -32193,6 +32883,7 @@ class Ghana(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -32216,6 +32907,11 @@ class Ghana(Country):
             TACAN_beacon = vehicles.Fortification.TACAN_beacon
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -32270,6 +32966,7 @@ class Ghana(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -32316,6 +33013,7 @@ class Ghana(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -32503,6 +33201,7 @@ class Nigeria(Country):
         class Artillery:
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -32529,6 +33228,11 @@ class Nigeria(Country):
 
         class Unarmed:
             KrAZ6322 = vehicles.Unarmed.KrAZ6322
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -32590,6 +33294,7 @@ class Nigeria(Country):
         C_101CC = planes.C_101CC
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -32637,6 +33342,7 @@ class Nigeria(Country):
         Plane.C_101CC,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
@@ -32828,6 +33534,7 @@ class Peru(Country):
             M_109 = vehicles.Artillery.M_109
             Tt_B8M1 = vehicles.Artillery.Tt_B8M1
             HL_B8M1 = vehicles.Artillery.HL_B8M1
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class Infantry:
             Infantry_AK = vehicles.Infantry.Infantry_AK
@@ -32858,6 +33565,11 @@ class Peru(Country):
             TACAN_beacon = vehicles.Fortification.TACAN_beacon
 
         class Unarmed:
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -32923,6 +33635,7 @@ class Peru(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_A_18A = planes.F_A_18A
@@ -32975,6 +33688,7 @@ class Peru(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_A_18A,
@@ -33164,6 +33878,7 @@ class Ecuador(Country):
         class Artillery:
             Grad_URAL = vehicles.Artillery.Grad_URAL
             X_2B11_mortar = vehicles.Artillery.X_2B11_mortar
+            L118_Unit = vehicles.Artillery.L118_Unit
 
         class AirDefence:
             Bofors40 = vehicles.AirDefence.Bofors40
@@ -33189,6 +33904,11 @@ class Ecuador(Country):
         class Unarmed:
             M_818 = vehicles.Unarmed.M_818
             Hummer = vehicles.Unarmed.Hummer
+            TugHarlan_drivable = vehicles.Unarmed.TugHarlan_drivable
+            B600_drivable = vehicles.Unarmed.B600_drivable
+            MJ_1_drivable = vehicles.Unarmed.MJ_1_drivable
+            P20_drivable = vehicles.Unarmed.P20_drivable
+            R11_volvo_drivable = vehicles.Unarmed.R11_volvo_drivable
             Tacr2a = vehicles.Unarmed.Tacr2a
             LARC_V = vehicles.Unarmed.LARC_V
 
@@ -33247,6 +33967,7 @@ class Ecuador(Country):
         JF_17 = planes.JF_17
         Christen_Eagle_II = planes.Christen_Eagle_II
         F_15ESE = planes.F_15ESE
+        F_4E_45MC = planes.F_4E_45MC
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
@@ -33295,6 +34016,7 @@ class Ecuador(Country):
         Plane.JF_17,
         Plane.Christen_Eagle_II,
         Plane.F_15ESE,
+        Plane.F_4E_45MC,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,

--- a/dcs/helicopters.py
+++ b/dcs/helicopters.py
@@ -27,14 +27,14 @@ class Mi_24V(HelicopterType):
     livery_name = "MI-24V"  # from type
 
     class Pylon1:
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
 
     class Pylon2:
         B_8V20A_CM = (2, Weapons.B_8V20A_CM)
         B_8V20A_OFP2 = (2, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (2, Weapons.B_8V20A_OM)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (2, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (2, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (2, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (2, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -81,7 +81,7 @@ class Mi_24V(HelicopterType):
         B_8V20A_OFP2 = (5, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (5, Weapons.B_8V20A_OM)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (5, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (5, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (5, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (5, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -90,7 +90,7 @@ class Mi_24V(HelicopterType):
         GUV_VOG = (5, Weapons.GUV_VOG)
 
     class Pylon6:
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (6, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (6, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
 
     pylons: Set[int] = {1, 2, 3, 4, 5, 6}
 
@@ -892,7 +892,7 @@ class Mi_28N(HelicopterType):
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
         B_8V20A_OFP2 = (1, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (1, Weapons.B_8V20A_OM)
-        _8_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._8_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _8_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._8_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
         B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (1, Weapons.B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         FAB_250___250kg_GP_Bomb_LD = (1, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_250_M62___250_kg_GP_Bomb_LD = (1, Weapons.FAB_250_M62___250_kg_GP_Bomb_LD)
@@ -947,7 +947,7 @@ class Mi_28N(HelicopterType):
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (4, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        _8_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (4, Weapons._8_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _8_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (4, Weapons._8_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
         B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (4, Weapons.B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
 
     pylons: Set[int] = {1, 2, 3, 4}
@@ -1515,7 +1515,7 @@ class Ka_50(HelicopterType):
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
         B_8V20A_OFP2 = (1, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (1, Weapons.B_8V20A_OM)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (1, Weapons.B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (1, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (1, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1559,7 +1559,7 @@ class Ka_50(HelicopterType):
         B_8V20A_CM = (4, Weapons.B_8V20A_CM)
         B_8V20A_OFP2 = (4, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (4, Weapons.B_8V20A_OM)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (4, Weapons.B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (4, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1750,7 +1750,7 @@ class Ka_50_3(HelicopterType):
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
         B_8V20A_OFP2 = (1, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (1, Weapons.B_8V20A_OM)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (1, Weapons.B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (1, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (1, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1794,7 +1794,7 @@ class Ka_50_3(HelicopterType):
         B_8V20A_CM = (4, Weapons.B_8V20A_CM)
         B_8V20A_OFP2 = (4, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (4, Weapons.B_8V20A_OM)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (4, Weapons.B_8V20A___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod = (4, Weapons.UPK_23_250___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -2081,7 +2081,7 @@ class Mi_24P(HelicopterType):
     livery_name = "MI-24P"  # from type
 
     class Pylon1:
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
         _2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT = (1, Weapons._2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT)
         _2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE = (1, Weapons._2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE)
         _2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag = (1, Weapons._2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag)
@@ -2092,7 +2092,7 @@ class Mi_24P(HelicopterType):
         B_8V20A_OFP2 = (2, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (2, Weapons.B_8V20A_OM)
         UB_32A_24_pod___32_x_S_5KO = (2, Weapons.UB_32A_24_pod___32_x_S_5KO)
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT_ = (2, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT_)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT_ = (2, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT_)
         _2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT_ = (2, Weapons._2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT_)
         _2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE_ = (2, Weapons._2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE_)
         _2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag_ = (2, Weapons._2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag_)
@@ -2158,7 +2158,7 @@ class Mi_24P(HelicopterType):
         B_8V20A_OFP2 = (5, Weapons.B_8V20A_OFP2)
         B_8V20A_OM = (5, Weapons.B_8V20A_OM)
         UB_32A_24_pod___32_x_S_5KO = (5, Weapons.UB_32A_24_pod___32_x_S_5KO)
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT_ = (5, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT_)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT_ = (5, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT_)
         _2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT_ = (5, Weapons._2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT_)
         _2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE_ = (5, Weapons._2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE_)
         _2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag_ = (5, Weapons._2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag_)
@@ -2176,7 +2176,7 @@ class Mi_24P(HelicopterType):
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___ = (5, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___)
 
     class Pylon6:
-        _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (6, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
+        _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = (6, Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT)
         _2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT = (6, Weapons._2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT)
         _2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE = (6, Weapons._2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE)
         _2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag = (6, Weapons._2_x_9M220O_Ataka__AT_9_Spiral_2____AAM__SACLOS__Frag)

--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -311,7 +311,7 @@ class F_4E(PlaneType):
         _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (1, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (1, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         F_4_Fuel_tank_W = (1, Weapons.F_4_Fuel_tank_W)
-        LAU_118A___AGM_45B_Shrike_ARM__Imp_ = (1, Weapons.LAU_118A___AGM_45B_Shrike_ARM__Imp_)
+        LAU_118A___AGM_45B_Shrike_ARM = (1, Weapons.LAU_118A___AGM_45B_Shrike_ARM)
         AGM_45A_Shrike_ARM = (1, Weapons.AGM_45A_Shrike_ARM)
 
     class Pylon2:
@@ -325,7 +325,7 @@ class F_4E(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (2, Weapons.LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_ = (2, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_)
-        LAU_118A___AGM_45B_Shrike_ARM__Imp_ = (2, Weapons.LAU_118A___AGM_45B_Shrike_ARM__Imp_)
+        LAU_118A___AGM_45B_Shrike_ARM = (2, Weapons.LAU_118A___AGM_45B_Shrike_ARM)
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_7_with_AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (2, Weapons.LAU_7_with_AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
@@ -334,22 +334,22 @@ class F_4E(PlaneType):
     class Pylon3:
         AIM_7M_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         ALQ_131___ECM_Pod = (3, Weapons.ALQ_131___ECM_Pod)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon4:
         AIM_7M_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon5:
         F_4_Fuel_tank_C = (5, Weapons.F_4_Fuel_tank_C)
 
     class Pylon6:
         AIM_7M_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon7:
         AIM_7M_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon8:
         LAU_7_with_2_x_AIM_9L_Sidewinder_IR_AAM = (8, Weapons.LAU_7_with_2_x_AIM_9L_Sidewinder_IR_AAM)
@@ -362,7 +362,7 @@ class F_4E(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (8, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM__ = (8, Weapons.LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM__)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__ = (8, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__)
-        LAU_118A___AGM_45B_Shrike_ARM__Imp_ = (8, Weapons.LAU_118A___AGM_45B_Shrike_ARM__Imp_)
+        LAU_118A___AGM_45B_Shrike_ARM = (8, Weapons.LAU_118A___AGM_45B_Shrike_ARM)
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         AGM_45A_Shrike_ARM = (8, Weapons.AGM_45A_Shrike_ARM)
@@ -378,7 +378,7 @@ class F_4E(PlaneType):
         _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         F_4_Fuel_tank_W = (9, Weapons.F_4_Fuel_tank_W)
-        LAU_118A___AGM_45B_Shrike_ARM__Imp_ = (9, Weapons.LAU_118A___AGM_45B_Shrike_ARM__Imp_)
+        LAU_118A___AGM_45B_Shrike_ARM = (9, Weapons.LAU_118A___AGM_45B_Shrike_ARM)
         AGM_45A_Shrike_ARM = (9, Weapons.AGM_45A_Shrike_ARM)
 
     pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9}
@@ -403,11 +403,11 @@ class MiG_27K(PlaneType):
     livery_name = "MIG-27K"  # from type
 
     class Pylon2:
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (2, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (2, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (2, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (2, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
@@ -460,11 +460,11 @@ class MiG_27K(PlaneType):
         APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (7, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon8:
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (8, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
@@ -894,7 +894,7 @@ class Su_25(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (3, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -924,7 +924,7 @@ class Su_25(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (4, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (4, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -954,7 +954,7 @@ class Su_25(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (5, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (5, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -985,7 +985,7 @@ class Su_25(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (6, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (6, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (6, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -1016,7 +1016,7 @@ class Su_25(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (7, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (7, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -1046,7 +1046,7 @@ class Su_25(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (8, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (8, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -1171,8 +1171,8 @@ class Su_25TM(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (3, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -1201,8 +1201,8 @@ class Su_25TM(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag = (4, Weapons.APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (4, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -1234,8 +1234,8 @@ class Su_25TM(PlaneType):
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (5, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (5, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = (5, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_ = (5, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_)
@@ -1274,8 +1274,8 @@ class Su_25TM(PlaneType):
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (7, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = (7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_)
@@ -1307,8 +1307,8 @@ class Su_25TM(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag = (8, Weapons.APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (8, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -1338,8 +1338,8 @@ class Su_25TM(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (9, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (9, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (9, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (9, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -1470,8 +1470,8 @@ class Su_25T(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (3, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -1502,8 +1502,8 @@ class Su_25T(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag = (4, Weapons.APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (4, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -1536,8 +1536,8 @@ class Su_25T(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (5, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (5, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -1574,8 +1574,8 @@ class Su_25T(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (7, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -1607,8 +1607,8 @@ class Su_25T(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag = (8, Weapons.APU_8___8_x_9M127_Vikhr___ATGM__LOSBR__Tandem_HEAT_Frag)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (8, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -1640,8 +1640,8 @@ class Su_25T(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (9, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (9, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (9, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (9, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -2140,8 +2140,8 @@ class Su_30(PlaneType):
         R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (3, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (3, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (3, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
@@ -2173,8 +2173,8 @@ class Su_30(PlaneType):
         R_77__AA_12_Adder____Active_Rdr = (4, Weapons.R_77__AA_12_Adder____Active_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (4, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (4, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (4, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (4, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_250_M62___250_kg_GP_Bomb_LD = (4, Weapons.FAB_250_M62___250_kg_GP_Bomb_LD)
@@ -2236,8 +2236,8 @@ class Su_30(PlaneType):
         R_77__AA_12_Adder____Active_Rdr = (7, Weapons.R_77__AA_12_Adder____Active_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_250_M62___250_kg_GP_Bomb_LD = (7, Weapons.FAB_250_M62___250_kg_GP_Bomb_LD)
@@ -2261,8 +2261,8 @@ class Su_30(PlaneType):
         R_73__AA_11_Archer____Infra_Red = (8, Weapons.R_73__AA_11_Archer____Infra_Red)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (8, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (8, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (8, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
@@ -2338,8 +2338,8 @@ class Su_17M4(PlaneType):
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (1, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Fuel_tank_1150L = (1, Weapons.Fuel_tank_1150L)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (1, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -2373,11 +2373,11 @@ class Su_17M4(PlaneType):
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
         MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (3, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (3, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -2443,11 +2443,11 @@ class Su_17M4(PlaneType):
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (6, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (6, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (6, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (6, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (6, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (6, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (6, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (6, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (6, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
@@ -2480,8 +2480,8 @@ class Su_17M4(PlaneType):
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Fuel_tank_1150L = (8, Weapons.Fuel_tank_1150L)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -2595,8 +2595,8 @@ class Su_24M(PlaneType):
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (1, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (1, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         S_25_O___420mm_UnGd_Rkt__380kg_Frag = (1, Weapons.S_25_O___420mm_UnGd_Rkt__380kg_Frag)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (1, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
         APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
@@ -2606,14 +2606,14 @@ class Su_24M(PlaneType):
 
     class Pylon2:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (2, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (2, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (2, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (2, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (2, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (2, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (2, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (2, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -2696,14 +2696,14 @@ class Su_24M(PlaneType):
 
     class Pylon7:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (7, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (7, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (7, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -2746,8 +2746,8 @@ class Su_24M(PlaneType):
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         S_25_O___420mm_UnGd_Rkt__380kg_Frag = (8, Weapons.S_25_O___420mm_UnGd_Rkt__380kg_Frag)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (8, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
         APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (8, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
@@ -3014,7 +3014,7 @@ class F_15C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon5:
         AIM_120B_AMRAAM___Active_Radar_AAM = (5, Weapons.AIM_120B_AMRAAM___Active_Radar_AAM)
@@ -3022,7 +3022,7 @@ class F_15C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (5, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon6:
         Fuel_tank_610_gal = (6, Weapons.Fuel_tank_610_gal)
@@ -3033,7 +3033,7 @@ class F_15C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon8:
         AIM_120B_AMRAAM___Active_Radar_AAM = (8, Weapons.AIM_120B_AMRAAM___Active_Radar_AAM)
@@ -3041,7 +3041,7 @@ class F_15C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 
     class Pylon9:
         AIM_120B_AMRAAM___Active_Radar_AAM = (9, Weapons.AIM_120B_AMRAAM___Active_Radar_AAM)
@@ -5449,7 +5449,7 @@ class SpitfireLFMkIX(PlaneType):
     height = 4.77
     width = 11.25
     length = 12.13
-    fuel_max = 247
+    fuel_max = 277.59853044
     max_speed = 828
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
@@ -5495,7 +5495,7 @@ class SpitfireLFMkIXCW(PlaneType):
     height = 4.77
     width = 11.25
     length = 12.13
-    fuel_max = 247
+    fuel_max = 277.59853044
     max_speed = 828
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
@@ -8973,7 +8973,7 @@ class AV8BNA(PlaneType):
         "GBULaserCode100": UnitPropertyDescription(
             identifier="GBULaserCode100",
             control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
+            label="Laser code for GBUs, 1x11",
             minimum=5,
             maximum=8,
             default=6,
@@ -8982,7 +8982,7 @@ class AV8BNA(PlaneType):
         "GBULaserCode10": UnitPropertyDescription(
             identifier="GBULaserCode10",
             control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
+            label="Laser code for GBUs, 11x1",
             minimum=1,
             maximum=8,
             default=8,
@@ -8991,7 +8991,7 @@ class AV8BNA(PlaneType):
         "GBULaserCode1": UnitPropertyDescription(
             identifier="GBULaserCode1",
             control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
+            label="Laser code for GBUs, 111x",
             minimum=1,
             maximum=8,
             default=8,
@@ -10745,7 +10745,7 @@ class F_15ESE(PlaneType):
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (2, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (2, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
@@ -10799,7 +10799,7 @@ class F_15ESE(PlaneType):
         GBU_12___4 = (4, Weapons.GBU_12___4)
         GBU_10___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_10___2 = (4, Weapons.GBU_10___2)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (4, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___2 = (4, Weapons.GBU_31_V_1_B___2)
@@ -10852,7 +10852,7 @@ class F_15ESE(PlaneType):
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (8, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
@@ -10917,7 +10917,7 @@ class F_15ESE(PlaneType):
         GBU_12___4_ = (12, Weapons.GBU_12___4_)
         GBU_10___2000lb_Laser_Guided_Bomb = (12, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_10___2_ = (12, Weapons.GBU_10___2_)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (12, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (12, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (12, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (12, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___2_ = (12, Weapons.GBU_31_V_1_B___2_)
@@ -10960,7 +10960,7 @@ class F_15ESE(PlaneType):
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (14, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         GBU_10___2000lb_Laser_Guided_Bomb = (14, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (14, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (14, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (14, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (14, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (14, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (14, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
@@ -11077,9 +11077,6 @@ class F_16C_50(PlaneType):
 
     property_defaults: Dict[str, Any] = {
         "LAU3ROF": 0,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "HelmetMountedDevice": 1,
         "VoiceCallsignLabel": None,
         "VoiceCallsignNumber": None,
@@ -11094,15 +11091,6 @@ class F_16C_50(PlaneType):
             class Values:
                 Single = 0
                 Ripple = 1
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class HelmetMountedDevice:
             id = "HelmetMountedDevice"
@@ -11133,36 +11121,6 @@ class F_16C_50(PlaneType):
                 0: "Single",
                 1: "Ripple",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
         ),
         "HelmetMountedDevice": UnitPropertyDescription(
             identifier="HelmetMountedDevice",
@@ -11258,7 +11216,7 @@ class F_16C_50(PlaneType):
         Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD = (3, Weapons.Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
@@ -11328,7 +11286,7 @@ class F_16C_50(PlaneType):
         Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD = (4, Weapons.Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD)
@@ -11374,7 +11332,7 @@ class F_16C_50(PlaneType):
         Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD = (6, Weapons.Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (6, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (6, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (6, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (6, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (6, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = (6, Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD)
@@ -11422,7 +11380,7 @@ class F_16C_50(PlaneType):
         Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD = (7, Weapons.Mk_84_AIR__BSU_50____2000_lb_TP_Chute_Retarded_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (7, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
@@ -11520,6 +11478,771 @@ class F_16C_50(PlaneType):
     task_default = task.CAP
 
 
+class F_4E_45MC(PlaneType):
+    id = "F-4E-45MC"
+    flyable = True
+    height = 5
+    width = 11.7
+    length = 19.2
+    fuel_max = 5510.5
+    max_speed = 2203.2
+    chaff = 120
+    flare = 30
+    charge_total = 150
+    chaff_charge_size = 1
+    flare_charge_size = 1
+    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    radio_frequency = 305
+
+    panel_radio = {
+        1: {
+            "channels": {
+                1: 305,
+                2: 264,
+                4: 256,
+                8: 257,
+                16: 261,
+                17: 267,
+                9: 255,
+                18: 251,
+                5: 254,
+                10: 262,
+                11: 259,
+                3: 265,
+                6: 250,
+                12: 268,
+                13: 269,
+                7: 270,
+                14: 260,
+                15: 263
+            },
+        },
+        2: {
+            "channels": {
+                1: 284,
+                2: 283,
+                4: 281,
+                8: 277,
+                16: 273,
+                17: 267,
+                9: 276,
+                18: 272,
+                5: 280,
+                10: 275,
+                20: 266,
+                11: 274,
+                3: 265,
+                6: 279,
+                12: 268,
+                13: 269,
+                7: 270,
+                14: 271,
+                19: 282,
+                15: 278
+            },
+        },
+    }
+
+    property_defaults: Dict[str, Any] = {
+        "Quality": 100,
+        "Wear": 0,
+        "UseReferenceAircraft": False,
+        "INSAlignmentStored": False,
+        "IsNvgAllowed": True,
+        "TacanChannel": 0,
+        "TacanBand": 0,
+        "VORILSFrequencyMHZ": 108,
+        "VORILSFrequencyDecimalMHZ": 0,
+        "KY28Key": 1,
+        "ChaffDoubleDispense": False,
+        "IffMode2Digit1": 0,
+        "IffMode2Digit2": 0,
+        "IffMode2Digit3": 0,
+        "IffMode2Digit4": 0,
+        "LaserCodeDigit1": 1,
+        "LaserCodeDigit2": 6,
+        "LaserCodeDigit3": 8,
+        "LaserCodeDigit4": 8,
+    }
+
+    class Properties:
+
+        class Quality:
+            id = "Quality"
+
+        class Wear:
+            id = "Wear"
+
+        class UseReferenceAircraft:
+            id = "UseReferenceAircraft"
+
+        class INSAlignmentStored:
+            id = "INSAlignmentStored"
+
+        class IsNvgAllowed:
+            id = "IsNvgAllowed"
+
+        class TacanChannel:
+            id = "TacanChannel"
+
+        class TacanBand:
+            id = "TacanBand"
+
+            class Values:
+                X = 0
+                Y = 1
+
+        class VORILSFrequencyMHZ:
+            id = "VORILSFrequencyMHZ"
+
+        class VORILSFrequencyDecimalMHZ:
+            id = "VORILSFrequencyDecimalMHZ"
+
+            class Values:
+                _00 = 0
+                _05 = 1
+                _10 = 2
+                _15 = 3
+                _20 = 4
+                _25 = 5
+                _30 = 6
+                _35 = 7
+                _40 = 8
+                _45 = 9
+                _50 = 10
+                _55 = 11
+                _60 = 12
+                _65 = 13
+                _70 = 14
+                _75 = 15
+                _80 = 16
+                _85 = 17
+                _90 = 18
+                _95 = 19
+
+        class KY28Key:
+            id = "KY28Key"
+
+        class ChaffDoubleDispense:
+            id = "ChaffDoubleDispense"
+
+        class IffMode2Digit1:
+            id = "IffMode2Digit1"
+
+        class IffMode2Digit2:
+            id = "IffMode2Digit2"
+
+        class IffMode2Digit3:
+            id = "IffMode2Digit3"
+
+        class IffMode2Digit4:
+            id = "IffMode2Digit4"
+
+        class LaserCodeDigit1:
+            id = "LaserCodeDigit1"
+
+        class LaserCodeDigit2:
+            id = "LaserCodeDigit2"
+
+        class LaserCodeDigit3:
+            id = "LaserCodeDigit3"
+
+        class LaserCodeDigit4:
+            id = "LaserCodeDigit4"
+
+    properties = {
+        "Quality": UnitPropertyDescription(
+            identifier="Quality",
+            control="spinbox",
+            label="Aircraft Condition",
+            player_only=True,
+            minimum=0,
+            maximum=100,
+            default=100,
+        ),
+        "Wear": UnitPropertyDescription(
+            identifier="Wear",
+            control="spinbox",
+            label="Aircraft Wear and Tear",
+            player_only=True,
+            minimum=0,
+            maximum=100,
+            default=0,
+        ),
+        "UseReferenceAircraft": UnitPropertyDescription(
+            identifier="UseReferenceAircraft",
+            control="checkbox",
+            label="Reference Aircraft",
+            player_only=True,
+            default=False,
+        ),
+        "INSAlignmentStored": UnitPropertyDescription(
+            identifier="INSAlignmentStored",
+            control="checkbox",
+            label="INS Reference Alignment Stored",
+            player_only=True,
+            default=False,
+        ),
+        "IsNvgAllowed": UnitPropertyDescription(
+            identifier="IsNvgAllowed",
+            control="checkbox",
+            label="Allow Night Vision Goggles",
+            player_only=True,
+            default=True,
+        ),
+        "TacanChannel": UnitPropertyDescription(
+            identifier="TacanChannel",
+            control="spinbox",
+            label="TACAN Channel Presel (0 = Auto)",
+            player_only=True,
+            minimum=0,
+            maximum=126,
+            default=0,
+        ),
+        "TacanBand": UnitPropertyDescription(
+            identifier="TacanBand",
+            control="comboList",
+            label="TACAN Band",
+            player_only=True,
+            default=0,
+            values={
+                0: "X",
+                1: "Y",
+            },
+        ),
+        "VORILSFrequencyMHZ": UnitPropertyDescription(
+            identifier="VORILSFrequencyMHZ",
+            control="spinbox",
+            label="VOR/ILS Frequency [MHz]",
+            player_only=True,
+            minimum=108,
+            maximum=117,
+            default=108,
+        ),
+        "VORILSFrequencyDecimalMHZ": UnitPropertyDescription(
+            identifier="VORILSFrequencyDecimalMHZ",
+            control="comboList",
+            label="VOR/ILS Frequency [decimal MHz]",
+            player_only=True,
+            default=0,
+            values={
+                0: ".00",
+                1: ".05",
+                2: ".10",
+                3: ".15",
+                4: ".20",
+                5: ".25",
+                6: ".30",
+                7: ".35",
+                8: ".40",
+                9: ".45",
+                10: ".50",
+                11: ".55",
+                12: ".60",
+                13: ".65",
+                14: ".70",
+                15: ".75",
+                16: ".80",
+                17: ".85",
+                18: ".90",
+                19: ".95",
+            },
+        ),
+        "KY28Key": UnitPropertyDescription(
+            identifier="KY28Key",
+            control="spinbox",
+            label="KY-28 Encryption Key",
+            player_only=True,
+            minimum=1,
+            maximum=255,
+            default=1,
+        ),
+        "ChaffDoubleDispense": UnitPropertyDescription(
+            identifier="ChaffDoubleDispense",
+            control="checkbox",
+            label="Chaff Double Dispense",
+            player_only=True,
+            default=False,
+        ),
+        "IffMode2Digit1": UnitPropertyDescription(
+            identifier="IffMode2Digit1",
+            control="spinbox",
+            label="IFF Mode 2 Code 1st Digit",
+            player_only=True,
+            minimum=0,
+            maximum=7,
+            default=0,
+            dimension=" ",
+        ),
+        "IffMode2Digit2": UnitPropertyDescription(
+            identifier="IffMode2Digit2",
+            control="spinbox",
+            label="IFF Mode 2 Code 2nd Digit",
+            player_only=True,
+            minimum=0,
+            maximum=7,
+            default=0,
+            dimension=" ",
+        ),
+        "IffMode2Digit3": UnitPropertyDescription(
+            identifier="IffMode2Digit3",
+            control="spinbox",
+            label="IFF Mode 2 Code 3rd Digit",
+            player_only=True,
+            minimum=0,
+            maximum=7,
+            default=0,
+            dimension=" ",
+        ),
+        "IffMode2Digit4": UnitPropertyDescription(
+            identifier="IffMode2Digit4",
+            control="spinbox",
+            label="IFF Mode 2 Code 4th Digit",
+            player_only=True,
+            minimum=0,
+            maximum=7,
+            default=0,
+            dimension=" ",
+        ),
+        "LaserCodeDigit1": UnitPropertyDescription(
+            identifier="LaserCodeDigit1",
+            control="spinbox",
+            label="Laser Code 1st Digit",
+            player_only=True,
+            minimum=1,
+            maximum=1,
+            default=1,
+            dimension=" ",
+        ),
+        "LaserCodeDigit2": UnitPropertyDescription(
+            identifier="LaserCodeDigit2",
+            control="spinbox",
+            label="Laser Code 2nd Digit",
+            player_only=True,
+            minimum=5,
+            maximum=7,
+            default=6,
+            dimension=" ",
+        ),
+        "LaserCodeDigit3": UnitPropertyDescription(
+            identifier="LaserCodeDigit3",
+            control="spinbox",
+            label="Laser Code 3rd Digit",
+            player_only=True,
+            minimum=1,
+            maximum=8,
+            default=8,
+            dimension=" ",
+        ),
+        "LaserCodeDigit4": UnitPropertyDescription(
+            identifier="LaserCodeDigit4",
+            control="spinbox",
+            label="Laser Code 4th Digit",
+            player_only=True,
+            minimum=1,
+            maximum=8,
+            default=8,
+            dimension=" ",
+        ),
+    }
+
+    livery_name = "F-4E-45MC"  # from type
+
+    class Pylon1:
+        _1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple = (1, Weapons._1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple)
+        _3x_M117___750lb_GP_Bomb_LD__MER_ = (1, Weapons._3x_M117___750lb_GP_Bomb_LD__MER_)
+        _3x_CBU_87___202_x_CEM_Cluster_Bomb__MER_ = (1, Weapons._3x_CBU_87___202_x_CEM_Cluster_Bomb__MER_)
+        _3x_CBU_52B___220_x_HE_Frag_bomblets__MER_ = (1, Weapons._3x_CBU_52B___220_x_HE_Frag_bomblets__MER_)
+        _2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER_ = (1, Weapons._2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER_)
+        _2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_ = (1, Weapons._2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_)
+        _2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_ = (1, Weapons._2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_)
+        _2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_ = (1, Weapons._2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_)
+        _1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_ = (1, Weapons._1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_)
+        _1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_ = (1, Weapons._1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_)
+        _1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_ = (1, Weapons._1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_)
+        Sargent_Fletcher_Fuel_Tank_370_gallons = (1, Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons)
+        Sargent_Fletcher_Fuel_Tank_370_gallons__empty_ = (1, Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons__empty_)
+        _6x_Mk_81___250lb_GP_Bomb_LD__MER_ = (1, Weapons._6x_Mk_81___250lb_GP_Bomb_LD__MER_)
+        _6x_Mk_82___500lb_GP_Bomb_LD__MER_ = (1, Weapons._6x_Mk_82___500lb_GP_Bomb_LD__MER_)
+        _6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_ = (1, Weapons._6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_)
+        _6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_ = (1, Weapons._6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_)
+        _6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_ = (1, Weapons._6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_)
+        _6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_ = (1, Weapons._6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_)
+        _6x_BDU_33___25lb_Practice_Bomb_LD__MER_ = (1, Weapons._6x_BDU_33___25lb_Practice_Bomb_LD__MER_)
+        _2x_Mk_83___1000lb_GP_Bomb_LD__MER_ = (1, Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__MER_)
+        CBU_87___202_x_CEM_Cluster_Bomb = (1, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
+        CBU_52B___220_x_HE_Frag_bomblets = (1, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
+        Mk_84___2000lb_GP_Bomb_LD = (1, Weapons.Mk_84___2000lb_GP_Bomb_LD)
+        Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD = (1, Weapons.Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD)
+        GBU_10___2000lb_Laser_Guided_Bomb = (1, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (1, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_12___500lb_Laser_Guided_Bomb = (1, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (1, Weapons.BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
+        GBU_8_HOBOS___2000_lb_TV_Guided_Bomb = (1, Weapons.GBU_8_HOBOS___2000_lb_TV_Guided_Bomb)
+        AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_ = (1, Weapons.AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (1, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (1, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (1, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_ = (1, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_ = (1, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_ = (1, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_)
+        SUU_25_x_8_LUU_2___Target_Marker_Flares = (1, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        AGM_45A_Shrike_ARM__LAU_34_ = (1, Weapons.AGM_45A_Shrike_ARM__LAU_34_)
+        AGM_12A_Bullpup_MCLOS_ASM__LAU_34_ = (1, Weapons.AGM_12A_Bullpup_MCLOS_ASM__LAU_34_)
+        AGM_12B_Bullpup_MCLOS_ASM__LAU_34_ = (1, Weapons.AGM_12B_Bullpup_MCLOS_ASM__LAU_34_)
+        SUU_23 = (1, Weapons.SUU_23)
+#ERRR <CLEAN>
+#ERRR <CLEAN>
+
+    class Pylon2:
+        AIM_9B_Sidewinder_IR_AAM = (2, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (2, Weapons.AIM_9J_Sidewinder_IR_AAM)
+        AIM_9P_Sidewinder_IR_AAM = (2, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM = (2, Weapons.AIM_9L_Sidewinder_IR_AAM)
+        AIM_9JULI_Sidewinder_IR_AAM = (2, Weapons.AIM_9JULI_Sidewinder_IR_AAM)
+        AIM_9M = (2, Weapons.AIM_9M)
+        CATM_9M = (2, Weapons.CATM_9M)
+        AIM_9P5_Sidewinder_IR_AAM = (2, Weapons.AIM_9P5_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (2, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+
+    class Pylon3:
+        _2x_Mk_83___1000lb_GP_Bomb_LD__TER_ = (3, Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__TER_)
+        _2x_M117___750lb_GP_Bomb_LD__TER_ = (3, Weapons._2x_M117___750lb_GP_Bomb_LD__TER_)
+        _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__ = (3, Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__)
+        _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__ = (3, Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__)
+        _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__ = (3, Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__)
+        _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__ = (3, Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__)
+        _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__ = (3, Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__)
+        _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__ = (3, Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__)
+        _3x_AGM_65A___Maverick_A__TV_Guided___LAU_88__ = (3, Weapons._3x_AGM_65A___Maverick_A__TV_Guided___LAU_88__)
+        _2x_AGM_65A___Maverick_A__TV_Guided___LAU_88__ = (3, Weapons._2x_AGM_65A___Maverick_A__TV_Guided___LAU_88__)
+        _3x_AGM_65B___Maverick_B__TV_Guided___LAU_88__ = (3, Weapons._3x_AGM_65B___Maverick_B__TV_Guided___LAU_88__)
+        _2x_AGM_65B___Maverick_B__TV_Guided___LAU_88__ = (3, Weapons._2x_AGM_65B___Maverick_B__TV_Guided___LAU_88__)
+        _3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__ = (3, Weapons._3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__)
+        _2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__ = (3, Weapons._2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__)
+        CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
+        _Special_Weapons_Adapter__CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons._Special_Weapons_Adapter__CBU_87___202_x_CEM_Cluster_Bomb)
+        _2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_ = (3, Weapons._2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_)
+        _Special_Weapons_Adapter__2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_)
+        CBU_52B___220_x_HE_Frag_bomblets = (3, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
+        _Special_Weapons_Adapter__CBU_52B___220_x_HE_Frag_bomblets = (3, Weapons._Special_Weapons_Adapter__CBU_52B___220_x_HE_Frag_bomblets)
+        _2x_CBU_52B___220_x_HE_Frag_bomblets__TER_ = (3, Weapons._2x_CBU_52B___220_x_HE_Frag_bomblets__TER_)
+        _Special_Weapons_Adapter__2x_CBU_52B___220_x_HE_Frag_bomblets__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_CBU_52B___220_x_HE_Frag_bomblets__TER_)
+        _3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_ = (3, Weapons._3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_)
+        _Special_Weapons_Adapter__3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_ = (3, Weapons._Special_Weapons_Adapter__3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_)
+        _3x_Mk_83___1000lb_GP_Bomb_LD__TER_ = (3, Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__TER_)
+        _3x_M117___750lb_GP_Bomb_LD__TER_ = (3, Weapons._3x_M117___750lb_GP_Bomb_LD__TER_)
+        Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD = (3, Weapons.Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
+        GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        _Special_Weapons_Adapter__GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons._Special_Weapons_Adapter__GBU_12___500lb_Laser_Guided_Bomb)
+        _2x_GBU_12___500lb_Laser_Guided_Bomb__TER_ = (3, Weapons._2x_GBU_12___500lb_Laser_Guided_Bomb__TER_)
+        _Special_Weapons_Adapter__2x_GBU_12___500lb_Laser_Guided_Bomb__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_GBU_12___500lb_Laser_Guided_Bomb__TER_)
+        BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (3, Weapons.BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
+        _Special_Weapons_Adapter__BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (3, Weapons._Special_Weapons_Adapter__BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
+        _2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_ = (3, Weapons._2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_)
+        _Special_Weapons_Adapter__2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_)
+        AGM_65G___Maverick_G__IIR_ASM___Lg_Whd___LAU_117_ = (3, Weapons.AGM_65G___Maverick_G__IIR_ASM___Lg_Whd___LAU_117_)
+        AGM_45A_Shrike_ARM__LAU_34_ = (3, Weapons.AGM_45A_Shrike_ARM__LAU_34_)
+        _Special_Weapons_Adapter__AGM_45A_Shrike_ARM__LAU_34_ = (3, Weapons._Special_Weapons_Adapter__AGM_45A_Shrike_ARM__LAU_34_)
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (3, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
+        AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_ = (3, Weapons.AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_)
+        GBU_8_HOBOS___2000_lb_TV_Guided_Bomb = (3, Weapons.GBU_8_HOBOS___2000_lb_TV_Guided_Bomb)
+        AGM_12A_Bullpup_MCLOS_ASM__LAU_34_ = (3, Weapons.AGM_12A_Bullpup_MCLOS_ASM__LAU_34_)
+        AGM_12B_Bullpup_MCLOS_ASM__LAU_34_ = (3, Weapons.AGM_12B_Bullpup_MCLOS_ASM__LAU_34_)
+        AGM_12C_Bullpup_MCLOS_ASM = (3, Weapons.AGM_12C_Bullpup_MCLOS_ASM)
+        _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (3, Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (3, Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (3, Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (3, Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (3, Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (3, Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
+        _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (3, Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (3, Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (3, Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (3, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (3, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (3, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
+        ALQ_131___ECM_Pod = (3, Weapons.ALQ_131___ECM_Pod)
+#ERRR <CLEAN>
+        _3x_Mk_81___250lb_GP_Bomb_LD__TER_ = (3, Weapons._3x_Mk_81___250lb_GP_Bomb_LD__TER_)
+        _2x_Mk_81___250lb_GP_Bomb_LD__TER_ = (3, Weapons._2x_Mk_81___250lb_GP_Bomb_LD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_81___250lb_GP_Bomb_LD__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_Mk_81___250lb_GP_Bomb_LD__TER_)
+        _3x_Mk_82___500lb_GP_Bomb_LD__TER_ = (3, Weapons._3x_Mk_82___500lb_GP_Bomb_LD__TER_)
+        _2x_Mk_82___500lb_GP_Bomb_LD__TER_ = (3, Weapons._2x_Mk_82___500lb_GP_Bomb_LD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_82___500lb_GP_Bomb_LD__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_Mk_82___500lb_GP_Bomb_LD__TER_)
+        _3x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = (3, Weapons._3x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_)
+        _2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = (3, Weapons._2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_)
+        _3x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = (3, Weapons._3x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_)
+        _2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = (3, Weapons._2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_)
+        _Special_Weapons_Adapter__2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_)
+        _3x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = (3, Weapons._3x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_)
+        _2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = (3, Weapons._2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_)
+        _3x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = (3, Weapons._3x_BDU_50LD___500lb_Practice_Bomb_LD__TER_)
+        _2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = (3, Weapons._2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_)
+        _Special_Weapons_Adapter__2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_)
+        _3x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = (3, Weapons._3x_BDU_50HD___500lb_Practice_Bomb_HD__TER_)
+        _2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = (3, Weapons._2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_)
+        _Special_Weapons_Adapter__2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = (3, Weapons._Special_Weapons_Adapter__2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_)
+        AGM_65A___Maverick_A__TV_Guided___LAU_117_ = (3, Weapons.AGM_65A___Maverick_A__TV_Guided___LAU_117_)
+        _Special_Weapons_Adapter__AGM_65A___Maverick_A__TV_Guided___LAU_117__Special_Weapons_Adapter__ = (3, Weapons._Special_Weapons_Adapter__AGM_65A___Maverick_A__TV_Guided___LAU_117__Special_Weapons_Adapter__)
+        AGM_65B___Maverick_B__TV_Guided___LAU_117_ = (3, Weapons.AGM_65B___Maverick_B__TV_Guided___LAU_117_)
+        _Special_Weapons_Adapter__AGM_65B___Maverick_B__TV_Guided___LAU_117__Special_Weapons_Adapter__ = (3, Weapons._Special_Weapons_Adapter__AGM_65B___Maverick_B__TV_Guided___LAU_117__Special_Weapons_Adapter__)
+        AGM_65D___Maverick_D__IIR_ASM___LAU_117_ = (3, Weapons.AGM_65D___Maverick_D__IIR_ASM___LAU_117_)
+        _Special_Weapons_Adapter__AGM_65D___Maverick_D__IIR_ASM___LAU_117__Special_Weapons_Adapter__ = (3, Weapons._Special_Weapons_Adapter__AGM_65D___Maverick_D__IIR_ASM___LAU_117__Special_Weapons_Adapter__)
+#ERRR <CLEAN>
+
+    class Pylon4:
+        AIM_9B_Sidewinder_IR_AAM = (4, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (4, Weapons.AIM_9J_Sidewinder_IR_AAM)
+        AIM_9P_Sidewinder_IR_AAM = (4, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM = (4, Weapons.AIM_9L_Sidewinder_IR_AAM)
+        AIM_9JULI_Sidewinder_IR_AAM = (4, Weapons.AIM_9JULI_Sidewinder_IR_AAM)
+        AIM_9M = (4, Weapons.AIM_9M)
+        CATM_9M = (4, Weapons.CATM_9M)
+        AIM_9P5_Sidewinder_IR_AAM = (4, Weapons.AIM_9P5_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (4, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+
+    class Pylon5:
+        AIM_7F = (5, Weapons.AIM_7F)
+        AIM_7E_Sparrow_Semi_Active_Radar_ = (5, Weapons.AIM_7E_Sparrow_Semi_Active_Radar_)
+        AIM_7E_2_Sparrow_Semi_Active_Radar_ = (5, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar_)
+        AIM_7M = (5, Weapons.AIM_7M)
+
+    class Pylon6:
+        AIM_7F = (6, Weapons.AIM_7F)
+        AIM_7E_Sparrow_Semi_Active_Radar_ = (6, Weapons.AIM_7E_Sparrow_Semi_Active_Radar_)
+        AIM_7E_2_Sparrow_Semi_Active_Radar_ = (6, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar_)
+        AIM_7M = (6, Weapons.AIM_7M)
+        AN_AVQ_23_Pave_Spike___Targeting_Pod_Rack = (6, Weapons.AN_AVQ_23_Pave_Spike___Targeting_Pod_Rack)
+        AN_AVQ_23_Pave_Spike__Fast_Smart_Track____Targeting_Pod_Rack = (6, Weapons.AN_AVQ_23_Pave_Spike__Fast_Smart_Track____Targeting_Pod_Rack)
+        ALQ_131___ECM_Pod_Rack = (6, Weapons.ALQ_131___ECM_Pod_Rack)
+
+    class Pylon7:
+        _6x_Mk_81___250lb_GP_Bomb_LD__MER_ = (7, Weapons._6x_Mk_81___250lb_GP_Bomb_LD__MER_)
+        _6x_Mk_82___500lb_GP_Bomb_LD__MER_ = (7, Weapons._6x_Mk_82___500lb_GP_Bomb_LD__MER_)
+        _6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_ = (7, Weapons._6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_)
+        _6x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__MER_ = (7, Weapons._6x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__MER_)
+        _6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_ = (7, Weapons._6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_)
+        _6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_ = (7, Weapons._6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_)
+        _6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_ = (7, Weapons._6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_)
+        _6x_BDU_33___25lb_Practice_Bomb_LD__MER_ = (7, Weapons._6x_BDU_33___25lb_Practice_Bomb_LD__MER_)
+        _6x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__MER_ = (7, Weapons._6x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__MER_)
+        _4x_CBU_87___202_x_CEM_Cluster_Bomb__MER_ = (7, Weapons._4x_CBU_87___202_x_CEM_Cluster_Bomb__MER_)
+#ERRR {HB_F4E_CBU-52B_6x}
+        _5x_M117___750lb_GP_Bomb_LD__MER_ = (7, Weapons._5x_M117___750lb_GP_Bomb_LD__MER_)
+        _3x_Mk_83___1000lb_GP_Bomb_LD__MER_ = (7, Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__MER_)
+        _3x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple = (7, Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple)
+        Mk_84___2000lb_GP_Bomb_LD = (7, Weapons.Mk_84___2000lb_GP_Bomb_LD)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_ = (7, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_ = (7, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_ = (7, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_)
+        _2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER___ = (7, Weapons._2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER___)
+        _1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER___ = (7, Weapons._1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER___)
+        _1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER___ = (7, Weapons._1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER___)
+        _1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER___ = (7, Weapons._1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER___)
+        SUU_23 = (7, Weapons.SUU_23)
+        Sargent_Fletcher_Fuel_Tank_600_gallons = (7, Weapons.Sargent_Fletcher_Fuel_Tank_600_gallons)
+        Sargent_Fletcher_Fuel_Tank_600_gallons__empty_ = (7, Weapons.Sargent_Fletcher_Fuel_Tank_600_gallons__empty_)
+
+    class Pylon8:
+        AIM_7F = (8, Weapons.AIM_7F)
+        AIM_7E_Sparrow_Semi_Active_Radar_ = (8, Weapons.AIM_7E_Sparrow_Semi_Active_Radar_)
+        AIM_7E_2_Sparrow_Semi_Active_Radar_ = (8, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar_)
+        AIM_7M = (8, Weapons.AIM_7M)
+
+    class Pylon9:
+        AIM_7F = (9, Weapons.AIM_7F)
+        AIM_7E_Sparrow_Semi_Active_Radar_ = (9, Weapons.AIM_7E_Sparrow_Semi_Active_Radar_)
+        AIM_7E_2_Sparrow_Semi_Active_Radar_ = (9, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar_)
+        AIM_7M = (9, Weapons.AIM_7M)
+#ERRR <CLEAN>
+
+    class Pylon10:
+        AIM_9B_Sidewinder_IR_AAM = (10, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (10, Weapons.AIM_9J_Sidewinder_IR_AAM)
+        AIM_9P_Sidewinder_IR_AAM = (10, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM = (10, Weapons.AIM_9L_Sidewinder_IR_AAM)
+        AIM_9JULI_Sidewinder_IR_AAM = (10, Weapons.AIM_9JULI_Sidewinder_IR_AAM)
+        AIM_9M = (10, Weapons.AIM_9M)
+        CATM_9M = (10, Weapons.CATM_9M)
+        AIM_9P5_Sidewinder_IR_AAM = (10, Weapons.AIM_9P5_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (10, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+
+    class Pylon11:
+        _2x_Mk_83___1000lb_GP_Bomb_LD__TER__ = (11, Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__TER__)
+        _2x_M117___750lb_GP_Bomb_LD__TER__ = (11, Weapons._2x_M117___750lb_GP_Bomb_LD__TER__)
+        _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (11, Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (11, Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (11, Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (11, Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (11, Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (11, Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _3x_AGM_65A___Maverick_A__TV_Guided___LAU_88_ = (11, Weapons._3x_AGM_65A___Maverick_A__TV_Guided___LAU_88_)
+        _2x_AGM_65A___Maverick_A__TV_Guided___LAU_88_ = (11, Weapons._2x_AGM_65A___Maverick_A__TV_Guided___LAU_88_)
+        _3x_AGM_65B___Maverick_B__TV_Guided___LAU_88_ = (11, Weapons._3x_AGM_65B___Maverick_B__TV_Guided___LAU_88_)
+        _2x_AGM_65B___Maverick_B__TV_Guided___LAU_88_ = (11, Weapons._2x_AGM_65B___Maverick_B__TV_Guided___LAU_88_)
+        _3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_ = (11, Weapons._3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_)
+        _2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_ = (11, Weapons._2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_)
+        CBU_87___202_x_CEM_Cluster_Bomb = (11, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
+        _Special_Weapons_Adapter__CBU_87___202_x_CEM_Cluster_Bomb = (11, Weapons._Special_Weapons_Adapter__CBU_87___202_x_CEM_Cluster_Bomb)
+        _2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_ = (11, Weapons._2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_)
+        _Special_Weapons_Adapter__2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_)
+        CBU_52B___220_x_HE_Frag_bomblets = (11, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
+        _Special_Weapons_Adapter__CBU_52B___220_x_HE_Frag_bomblets = (11, Weapons._Special_Weapons_Adapter__CBU_52B___220_x_HE_Frag_bomblets)
+        _2x_CBU_52B___220_x_HE_Frag_bomblets__TER_ = (11, Weapons._2x_CBU_52B___220_x_HE_Frag_bomblets__TER_)
+        _Special_Weapons_Adapter__2x_CBU_52B___220_x_HE_Frag_bomblets__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_CBU_52B___220_x_HE_Frag_bomblets__TER_)
+        _3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_ = (11, Weapons._3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_)
+        _Special_Weapons_Adapter__3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_ = (11, Weapons._Special_Weapons_Adapter__3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_)
+        _3x_Mk_83___1000lb_GP_Bomb_LD__TER_ = (11, Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__TER_)
+        _3x_M117___750lb_GP_Bomb_LD__TER_ = (11, Weapons._3x_M117___750lb_GP_Bomb_LD__TER_)
+        Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD = (11, Weapons.Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (11, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_10___2000lb_Laser_Guided_Bomb = (11, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
+        GBU_12___500lb_Laser_Guided_Bomb = (11, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        _Special_Weapons_Adapter__GBU_12___500lb_Laser_Guided_Bomb = (11, Weapons._Special_Weapons_Adapter__GBU_12___500lb_Laser_Guided_Bomb)
+        _2x_GBU_12___500lb_Laser_Guided_Bomb__TER_ = (11, Weapons._2x_GBU_12___500lb_Laser_Guided_Bomb__TER_)
+        _Special_Weapons_Adapter__2x_GBU_12___500lb_Laser_Guided_Bomb__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_GBU_12___500lb_Laser_Guided_Bomb__TER_)
+        BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (11, Weapons.BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
+        _Special_Weapons_Adapter__BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (11, Weapons._Special_Weapons_Adapter__BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
+        _2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_ = (11, Weapons._2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_)
+        _Special_Weapons_Adapter__2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_)
+        AGM_65G___Maverick_G__IIR_ASM___Lg_Whd___LAU_117_ = (11, Weapons.AGM_65G___Maverick_G__IIR_ASM___Lg_Whd___LAU_117_)
+        AGM_45A_Shrike_ARM__LAU_34_ = (11, Weapons.AGM_45A_Shrike_ARM__LAU_34_)
+        _Special_Weapons_Adapter__AGM_45A_Shrike_ARM__LAU_34_ = (11, Weapons._Special_Weapons_Adapter__AGM_45A_Shrike_ARM__LAU_34_)
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (11, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
+        AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_ = (11, Weapons.AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_)
+        GBU_8_HOBOS___2000_lb_TV_Guided_Bomb = (11, Weapons.GBU_8_HOBOS___2000_lb_TV_Guided_Bomb)
+        AGM_12A_Bullpup_MCLOS_ASM__LAU_34_ = (11, Weapons.AGM_12A_Bullpup_MCLOS_ASM__LAU_34_)
+        AGM_12B_Bullpup_MCLOS_ASM__LAU_34_ = (11, Weapons.AGM_12B_Bullpup_MCLOS_ASM__LAU_34_)
+        AGM_12C_Bullpup_MCLOS_ASM = (11, Weapons.AGM_12C_Bullpup_MCLOS_ASM)
+        _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (11, Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (11, Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (11, Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (11, Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (11, Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (11, Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (11, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (11, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (11, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
+        _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (11, Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (11, Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (11, Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = (11, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = (11, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = (11, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (11, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (11, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (11, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
+        ALQ_131___ECM_Pod = (11, Weapons.ALQ_131___ECM_Pod)
+#ERRR <CLEAN>
+        _3x_Mk_81___250lb_GP_Bomb_LD__TER_ = (11, Weapons._3x_Mk_81___250lb_GP_Bomb_LD__TER_)
+        _2x_Mk_81___250lb_GP_Bomb_LD__TER_ = (11, Weapons._2x_Mk_81___250lb_GP_Bomb_LD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_81___250lb_GP_Bomb_LD__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_Mk_81___250lb_GP_Bomb_LD__TER_)
+        _3x_Mk_82___500lb_GP_Bomb_LD__TER_ = (11, Weapons._3x_Mk_82___500lb_GP_Bomb_LD__TER_)
+        _2x_Mk_82___500lb_GP_Bomb_LD__TER_ = (11, Weapons._2x_Mk_82___500lb_GP_Bomb_LD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_82___500lb_GP_Bomb_LD__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_Mk_82___500lb_GP_Bomb_LD__TER_)
+        _3x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = (11, Weapons._3x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_)
+        _2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = (11, Weapons._2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_)
+        _3x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = (11, Weapons._3x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_)
+        _2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = (11, Weapons._2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_)
+        _Special_Weapons_Adapter__2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_)
+        _3x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = (11, Weapons._3x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_)
+        _2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = (11, Weapons._2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_)
+        _Special_Weapons_Adapter__2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_)
+        _3x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = (11, Weapons._3x_BDU_50LD___500lb_Practice_Bomb_LD__TER_)
+        _2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = (11, Weapons._2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_)
+        _Special_Weapons_Adapter__2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_)
+        _3x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = (11, Weapons._3x_BDU_50HD___500lb_Practice_Bomb_HD__TER_)
+        _2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = (11, Weapons._2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_)
+        _Special_Weapons_Adapter__2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = (11, Weapons._Special_Weapons_Adapter__2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_)
+        AGM_65A___Maverick_A__TV_Guided___LAU_117_ = (11, Weapons.AGM_65A___Maverick_A__TV_Guided___LAU_117_)
+        _Special_Weapons_Adapter__AGM_65A___Maverick_A__TV_Guided___LAU_117__Special_Weapons_Adapter__ = (11, Weapons._Special_Weapons_Adapter__AGM_65A___Maverick_A__TV_Guided___LAU_117__Special_Weapons_Adapter__)
+        AGM_65B___Maverick_B__TV_Guided___LAU_117_ = (11, Weapons.AGM_65B___Maverick_B__TV_Guided___LAU_117_)
+        _Special_Weapons_Adapter__AGM_65B___Maverick_B__TV_Guided___LAU_117__Special_Weapons_Adapter__ = (11, Weapons._Special_Weapons_Adapter__AGM_65B___Maverick_B__TV_Guided___LAU_117__Special_Weapons_Adapter__)
+        AGM_65D___Maverick_D__IIR_ASM___LAU_117_ = (11, Weapons.AGM_65D___Maverick_D__IIR_ASM___LAU_117_)
+        _Special_Weapons_Adapter__AGM_65D___Maverick_D__IIR_ASM___LAU_117__Special_Weapons_Adapter__ = (11, Weapons._Special_Weapons_Adapter__AGM_65D___Maverick_D__IIR_ASM___LAU_117__Special_Weapons_Adapter__)
+#ERRR <CLEAN>
+
+    class Pylon12:
+        AIM_9B_Sidewinder_IR_AAM = (12, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (12, Weapons.AIM_9J_Sidewinder_IR_AAM)
+        AIM_9P_Sidewinder_IR_AAM = (12, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9L_Sidewinder_IR_AAM = (12, Weapons.AIM_9L_Sidewinder_IR_AAM)
+        AIM_9JULI_Sidewinder_IR_AAM = (12, Weapons.AIM_9JULI_Sidewinder_IR_AAM)
+        AIM_9M = (12, Weapons.AIM_9M)
+        CATM_9M = (12, Weapons.CATM_9M)
+        AIM_9P5_Sidewinder_IR_AAM = (12, Weapons.AIM_9P5_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (12, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+
+    class Pylon13:
+        _1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple_ = (13, Weapons._1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple_)
+        _3x_M117___750lb_GP_Bomb_LD__MER__ = (13, Weapons._3x_M117___750lb_GP_Bomb_LD__MER__)
+        _3x_CBU_87___202_x_CEM_Cluster_Bomb__MER__ = (13, Weapons._3x_CBU_87___202_x_CEM_Cluster_Bomb__MER__)
+        _3x_CBU_52B___220_x_HE_Frag_bomblets__MER__ = (13, Weapons._3x_CBU_52B___220_x_HE_Frag_bomblets__MER__)
+        _2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER__ = (13, Weapons._2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER__)
+        _2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__ = (13, Weapons._2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__)
+        _2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__ = (13, Weapons._2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__)
+        _2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__ = (13, Weapons._2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__)
+        _1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__ = (13, Weapons._1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__)
+        _1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__ = (13, Weapons._1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__)
+        _1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__ = (13, Weapons._1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__)
+        Sargent_Fletcher_Fuel_Tank_370_gallons_ = (13, Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons_)
+        Sargent_Fletcher_Fuel_Tank_370_gallons__empty__ = (13, Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons__empty__)
+        _6x_Mk_81___250lb_GP_Bomb_LD__MER_ = (13, Weapons._6x_Mk_81___250lb_GP_Bomb_LD__MER_)
+        _6x_Mk_82___500lb_GP_Bomb_LD__MER_ = (13, Weapons._6x_Mk_82___500lb_GP_Bomb_LD__MER_)
+        _6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_ = (13, Weapons._6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_)
+        _6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_ = (13, Weapons._6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_)
+        _6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_ = (13, Weapons._6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_)
+        _6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_ = (13, Weapons._6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_)
+        _6x_BDU_33___25lb_Practice_Bomb_LD__MER_ = (13, Weapons._6x_BDU_33___25lb_Practice_Bomb_LD__MER_)
+        _2x_Mk_83___1000lb_GP_Bomb_LD__MER_ = (13, Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__MER_)
+        CBU_87___202_x_CEM_Cluster_Bomb = (13, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
+        CBU_52B___220_x_HE_Frag_bomblets = (13, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
+        Mk_84___2000lb_GP_Bomb_LD = (13, Weapons.Mk_84___2000lb_GP_Bomb_LD)
+        Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD = (13, Weapons.Mk_84_AIR__BSU_50____2000_lb_GP_Chute_Retarded_Bomb_HD)
+        GBU_10___2000lb_Laser_Guided_Bomb = (13, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (13, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_12___500lb_Laser_Guided_Bomb = (13, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (13, Weapons.BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
+        GBU_8_HOBOS___2000_lb_TV_Guided_Bomb = (13, Weapons.GBU_8_HOBOS___2000_lb_TV_Guided_Bomb)
+        AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_ = (13, Weapons.AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (13, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (13, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (13, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_ = (13, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_ = (13, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_)
+        _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_ = (13, Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_)
+        SUU_25_x_8_LUU_2___Target_Marker_Flares = (13, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        AGM_45A_Shrike_ARM__LAU_34_ = (13, Weapons.AGM_45A_Shrike_ARM__LAU_34_)
+        AGM_12A_Bullpup_MCLOS_ASM__LAU_34_ = (13, Weapons.AGM_12A_Bullpup_MCLOS_ASM__LAU_34_)
+        AGM_12B_Bullpup_MCLOS_ASM__LAU_34_ = (13, Weapons.AGM_12B_Bullpup_MCLOS_ASM__LAU_34_)
+        SUU_23 = (13, Weapons.SUU_23)
+#ERRR <CLEAN>
+
+    class Pylon14:
+        ALE_40_Dispensers__Empty_ = (14, Weapons.ALE_40_Dispensers__Empty_)
+        ALE_40_Dispensers__120_Chaff_ = (14, Weapons.ALE_40_Dispensers__120_Chaff_)
+        ALE_40_Dispensers__30_Flares__60_Chaff_ = (14, Weapons.ALE_40_Dispensers__30_Flares__60_Chaff_)
+        ALE_40_Dispensers__15_Flares__90_Chaff_ = (14, Weapons.ALE_40_Dispensers__15_Flares__90_Chaff_)
+        ALE_40_Dispensers__30_Flares_ = (14, Weapons.ALE_40_Dispensers__30_Flares_)
+
+    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
+
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.AFAC, task.SEAD, task.AntishipStrike, task.Reconnaissance]
+    task_default = task.CAP
+
+
 class F_5E(PlaneType):
     id = "F-5E"
     height = 4.06
@@ -11539,6 +12262,7 @@ class F_5E(PlaneType):
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (1, Weapons.AIM_9J_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (1, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9P3_Sidewinder_IR_AAM = (1, Weapons.AIM_9P3_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (1, Weapons.AIM_9P_Sidewinder_IR_AAM)
@@ -11699,6 +12423,7 @@ class F_5E(PlaneType):
 
     class Pylon7:
         AIM_9B_Sidewinder_IR_AAM = (7, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (7, Weapons.AIM_9J_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (7, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9P3_Sidewinder_IR_AAM = (7, Weapons.AIM_9P3_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (7, Weapons.AIM_9P_Sidewinder_IR_AAM)
@@ -11763,9 +12488,6 @@ class F_5E_3(PlaneType):
     property_defaults: Dict[str, Any] = {
         "LAU3ROF": 0,
         "LAU68ROF": 0,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "ChaffBurst": 0,
         "ChaffSalvo": 0,
         "ChaffBurstInt": 0,
@@ -11791,15 +12513,6 @@ class F_5E_3(PlaneType):
             class Values:
                 Single = 0
                 Ripple__60ms = 1
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class ChaffBurst:
             id = "ChaffBurst"
@@ -11889,36 +12602,6 @@ class F_5E_3(PlaneType):
                 0: "Single",
                 1: "Ripple, 60ms",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
         ),
         "ChaffBurst": UnitPropertyDescription(
             identifier="ChaffBurst",
@@ -12018,6 +12701,7 @@ class F_5E_3(PlaneType):
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (1, Weapons.AIM_9J_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (1, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9P3_Sidewinder_IR_AAM = (1, Weapons.AIM_9P3_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (1, Weapons.AIM_9P_Sidewinder_IR_AAM)
@@ -12178,6 +12862,7 @@ class F_5E_3(PlaneType):
 
     class Pylon7:
         AIM_9B_Sidewinder_IR_AAM = (7, Weapons.AIM_9B_Sidewinder_IR_AAM)
+        AIM_9J_Sidewinder_IR_AAM = (7, Weapons.AIM_9J_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (7, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9P3_Sidewinder_IR_AAM = (7, Weapons.AIM_9P3_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (7, Weapons.AIM_9P_Sidewinder_IR_AAM)
@@ -12581,8 +13266,8 @@ class F_14B(PlaneType):
         AIM_54C_Mk60_ = (2, Weapons.AIM_54C_Mk60_)
         AIM_54A_Mk47_ = (2, Weapons.AIM_54A_Mk47_)
         AIM_54A_Mk60_ = (2, Weapons.AIM_54A_Mk60_)
-        AIM_7M = (2, Weapons.AIM_7M)
-        AIM_7F = (2, Weapons.AIM_7F)
+        AIM_7M_ = (2, Weapons.AIM_7M_)
+        AIM_7F_ = (2, Weapons.AIM_7F_)
         AIM_7MH = (2, Weapons.AIM_7MH)
         LAU_7_AIM_9M = (2, Weapons.LAU_7_AIM_9M)
         LAU_7_AIM_9L = (2, Weapons.LAU_7_AIM_9L)
@@ -12609,8 +13294,8 @@ class F_14B(PlaneType):
         AIM_54A_Mk60 = (4, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (4, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (4, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (4, Weapons.AIM_7M_)
-        AIM_7F_ = (4, Weapons.AIM_7F_)
+        AIM_7M__ = (4, Weapons.AIM_7M__)
+        AIM_7F__ = (4, Weapons.AIM_7F__)
         AIM_7MH_ = (4, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (4, Weapons.AIM_7P_)
@@ -12645,8 +13330,8 @@ class F_14B(PlaneType):
         AIM_54A_Mk60 = (5, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (5, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (5, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (5, Weapons.AIM_7M_)
-        AIM_7F_ = (5, Weapons.AIM_7F_)
+        AIM_7M__ = (5, Weapons.AIM_7M__)
+        AIM_7F__ = (5, Weapons.AIM_7F__)
         AIM_7MH_ = (5, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (5, Weapons.AIM_7P_)
@@ -12679,8 +13364,8 @@ class F_14B(PlaneType):
         AIM_54A_Mk60 = (6, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (6, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (6, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (6, Weapons.AIM_7M_)
-        AIM_7F_ = (6, Weapons.AIM_7F_)
+        AIM_7M__ = (6, Weapons.AIM_7M__)
+        AIM_7F__ = (6, Weapons.AIM_7F__)
         AIM_7MH_ = (6, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (6, Weapons.AIM_7P_)
@@ -12713,8 +13398,8 @@ class F_14B(PlaneType):
         AIM_54A_Mk60 = (7, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (7, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (7, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (7, Weapons.AIM_7M_)
-        AIM_7F_ = (7, Weapons.AIM_7F_)
+        AIM_7M__ = (7, Weapons.AIM_7M__)
+        AIM_7F__ = (7, Weapons.AIM_7F__)
         AIM_7MH_ = (7, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (7, Weapons.AIM_7P_)
@@ -12753,8 +13438,8 @@ class F_14B(PlaneType):
         AIM_54C_Mk60__ = (9, Weapons.AIM_54C_Mk60__)
         AIM_54A_Mk47__ = (9, Weapons.AIM_54A_Mk47__)
         AIM_54A_Mk60__ = (9, Weapons.AIM_54A_Mk60__)
-        AIM_7M = (9, Weapons.AIM_7M)
-        AIM_7F = (9, Weapons.AIM_7F)
+        AIM_7M_ = (9, Weapons.AIM_7M_)
+        AIM_7F_ = (9, Weapons.AIM_7F_)
         AIM_7MH = (9, Weapons.AIM_7MH)
         LAU_7_AIM_9M = (9, Weapons.LAU_7_AIM_9M)
         LAU_7_AIM_9L = (9, Weapons.LAU_7_AIM_9L)
@@ -13083,8 +13768,8 @@ class F_14A_135_GR(PlaneType):
         AIM_54C_Mk60_ = (2, Weapons.AIM_54C_Mk60_)
         AIM_54A_Mk47_ = (2, Weapons.AIM_54A_Mk47_)
         AIM_54A_Mk60_ = (2, Weapons.AIM_54A_Mk60_)
-        AIM_7M = (2, Weapons.AIM_7M)
-        AIM_7F = (2, Weapons.AIM_7F)
+        AIM_7M_ = (2, Weapons.AIM_7M_)
+        AIM_7F_ = (2, Weapons.AIM_7F_)
         AIM_7MH = (2, Weapons.AIM_7MH)
         LAU_7_AIM_9M = (2, Weapons.LAU_7_AIM_9M)
         LAU_7_AIM_9L = (2, Weapons.LAU_7_AIM_9L)
@@ -13111,8 +13796,8 @@ class F_14A_135_GR(PlaneType):
         AIM_54A_Mk60 = (4, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (4, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (4, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (4, Weapons.AIM_7M_)
-        AIM_7F_ = (4, Weapons.AIM_7F_)
+        AIM_7M__ = (4, Weapons.AIM_7M__)
+        AIM_7F__ = (4, Weapons.AIM_7F__)
         AIM_7MH_ = (4, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (4, Weapons.AIM_7P_)
@@ -13147,8 +13832,8 @@ class F_14A_135_GR(PlaneType):
         AIM_54A_Mk60 = (5, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (5, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (5, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (5, Weapons.AIM_7M_)
-        AIM_7F_ = (5, Weapons.AIM_7F_)
+        AIM_7M__ = (5, Weapons.AIM_7M__)
+        AIM_7F__ = (5, Weapons.AIM_7F__)
         AIM_7MH_ = (5, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (5, Weapons.AIM_7P_)
@@ -13181,8 +13866,8 @@ class F_14A_135_GR(PlaneType):
         AIM_54A_Mk60 = (6, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (6, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (6, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (6, Weapons.AIM_7M_)
-        AIM_7F_ = (6, Weapons.AIM_7F_)
+        AIM_7M__ = (6, Weapons.AIM_7M__)
+        AIM_7F__ = (6, Weapons.AIM_7F__)
         AIM_7MH_ = (6, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (6, Weapons.AIM_7P_)
@@ -13215,8 +13900,8 @@ class F_14A_135_GR(PlaneType):
         AIM_54A_Mk60 = (7, Weapons.AIM_54A_Mk60)
         AIM_54C_Mk47 = (7, Weapons.AIM_54C_Mk47)
         AIM_54C_Mk60 = (7, Weapons.AIM_54C_Mk60)
-        AIM_7M_ = (7, Weapons.AIM_7M_)
-        AIM_7F_ = (7, Weapons.AIM_7F_)
+        AIM_7M__ = (7, Weapons.AIM_7M__)
+        AIM_7F__ = (7, Weapons.AIM_7F__)
         AIM_7MH_ = (7, Weapons.AIM_7MH_)
 #ERRR <CLEAN>
         AIM_7P_ = (7, Weapons.AIM_7P_)
@@ -13255,8 +13940,8 @@ class F_14A_135_GR(PlaneType):
         AIM_54C_Mk60__ = (9, Weapons.AIM_54C_Mk60__)
         AIM_54A_Mk47__ = (9, Weapons.AIM_54A_Mk47__)
         AIM_54A_Mk60__ = (9, Weapons.AIM_54A_Mk60__)
-        AIM_7M = (9, Weapons.AIM_7M)
-        AIM_7F = (9, Weapons.AIM_7F)
+        AIM_7M_ = (9, Weapons.AIM_7M_)
+        AIM_7F_ = (9, Weapons.AIM_7F_)
         AIM_7MH = (9, Weapons.AIM_7MH)
         LAU_7_AIM_9M = (9, Weapons.LAU_7_AIM_9M)
         LAU_7_AIM_9L = (9, Weapons.LAU_7_AIM_9L)
@@ -13539,7 +14224,7 @@ class F_A_18C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         AGM_84A_Harpoon_ASM = (2, Weapons.AGM_84A_Harpoon_ASM)
         AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (2, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
@@ -13577,7 +14262,7 @@ class F_A_18C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         AGM_84A_Harpoon_ASM = (3, Weapons.AGM_84A_Harpoon_ASM)
         AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (3, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
         AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
@@ -13610,7 +14295,7 @@ class F_A_18C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
 #ERRR {6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}
 
     class Pylon5:
@@ -13623,7 +14308,7 @@ class F_A_18C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_ = (6, Weapons.AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_)
 
     class Pylon7:
@@ -13632,7 +14317,7 @@ class F_A_18C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         AGM_84A_Harpoon_ASM = (7, Weapons.AGM_84A_Harpoon_ASM)
         AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (7, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
         AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
@@ -13665,7 +14350,7 @@ class F_A_18C(PlaneType):
         AIM_7M_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AIM_7F_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
-        AIM_7E_2_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar)
+        AIM_7E_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         AGM_84A_Harpoon_ASM = (8, Weapons.AGM_84A_Harpoon_ASM)
         AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (8, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
@@ -13965,7 +14650,7 @@ class FA_18C_hornet(PlaneType):
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (2, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (2, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
-        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (2, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
@@ -14035,7 +14720,7 @@ class FA_18C_hornet(PlaneType):
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (3, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
-        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (3, Weapons.BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
@@ -14141,7 +14826,7 @@ class FA_18C_hornet(PlaneType):
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (7, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
-        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = (7, Weapons.BDU_45_LG___500lb_Practice_Laser_Guided_Bomb)
@@ -14211,7 +14896,7 @@ class FA_18C_hornet(PlaneType):
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (8, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
-        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (8, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
@@ -14815,6 +15500,7 @@ class M_2000C(PlaneType):
         "WpBullseye": 0,
         "ForceINSRules": False,
         "ReadyALCM": True,
+        "ReadyQRA": False,
         "LoadNVGCase": False,
         "InitHotDrift": 0,
         "EnableTAF": True,
@@ -14833,6 +15519,9 @@ class M_2000C(PlaneType):
 
         class ReadyALCM:
             id = "ReadyALCM"
+
+        class ReadyQRA:
+            id = "ReadyQRA"
 
         class LoadNVGCase:
             id = "LoadNVGCase"
@@ -14882,8 +15571,14 @@ class M_2000C(PlaneType):
         "ReadyALCM": UnitPropertyDescription(
             identifier="ReadyALCM",
             control="checkbox",
-            label="Aircraft is ALCM ready",
+            label="Cold start is ALCM ready",
             default=True,
+        ),
+        "ReadyQRA": UnitPropertyDescription(
+            identifier="ReadyQRA",
+            control="checkbox",
+            label="Hot start in QRA mode",
+            default=False,
         ),
         "LoadNVGCase": UnitPropertyDescription(
             identifier="LoadNVGCase",
@@ -14961,7 +15656,7 @@ class M_2000C(PlaneType):
         BLG_66_AC_Belouga = (5, Weapons.BLG_66_AC_Belouga)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (5, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
-        GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb)
+        GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb)
         BAP_100_x_6 = (5, Weapons.BAP_100_x_6)
         BAP_100_x_12 = (5, Weapons.BAP_100_x_12)
         BAP_100_x_18 = (5, Weapons.BAP_100_x_18)
@@ -16211,9 +16906,6 @@ class Mirage_F1C(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -16321,15 +17013,6 @@ class Mirage_F1C(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -16492,39 +17175,6 @@ class Mirage_F1C(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -16776,9 +17426,6 @@ class Mirage_F1CE(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "IFFMode4Disabled": 1,
     }
@@ -16887,15 +17534,6 @@ class Mirage_F1CE(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -17066,39 +17704,6 @@ class Mirage_F1CE(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -17403,9 +18008,6 @@ class Mirage_F1EE(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "IFFMode4Disabled": 1,
         "INSStartMode": 1,
@@ -17516,15 +18118,6 @@ class Mirage_F1EE(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -17709,39 +18302,6 @@ class Mirage_F1EE(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -18071,9 +18631,6 @@ class Mirage_F1M_EE(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -18181,15 +18738,6 @@ class Mirage_F1M_EE(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -18352,39 +18900,6 @@ class Mirage_F1M_EE(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -18677,9 +19192,6 @@ class Mirage_F1M_CE(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -18787,15 +19299,6 @@ class Mirage_F1M_CE(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -18958,39 +19461,6 @@ class Mirage_F1M_CE(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -19281,9 +19751,6 @@ class Mirage_F1C_200(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -19391,15 +19858,6 @@ class Mirage_F1C_200(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -19562,39 +20020,6 @@ class Mirage_F1C_200(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -19847,9 +20272,6 @@ class Mirage_F1EH(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -19957,15 +20379,6 @@ class Mirage_F1EH(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -20128,39 +20541,6 @@ class Mirage_F1EH(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -20413,9 +20793,6 @@ class Mirage_F1CH(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -20523,15 +20900,6 @@ class Mirage_F1CH(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -20694,39 +21062,6 @@ class Mirage_F1CH(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -20979,9 +21314,6 @@ class Mirage_F1JA(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -21089,15 +21421,6 @@ class Mirage_F1JA(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -21260,39 +21583,6 @@ class Mirage_F1JA(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -21529,9 +21819,6 @@ class Mirage_F1CG(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -21639,15 +21926,6 @@ class Mirage_F1CG(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -21810,39 +22088,6 @@ class Mirage_F1CG(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -22105,9 +22350,6 @@ class Mirage_F1CZ(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -22215,15 +22457,6 @@ class Mirage_F1CZ(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -22386,39 +22619,6 @@ class Mirage_F1CZ(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -22671,9 +22871,6 @@ class Mirage_F1CJ(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -22781,15 +22978,6 @@ class Mirage_F1CJ(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -22952,39 +23140,6 @@ class Mirage_F1CJ(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -23237,9 +23392,6 @@ class Mirage_F1CK(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -23347,15 +23499,6 @@ class Mirage_F1CK(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -23518,39 +23661,6 @@ class Mirage_F1CK(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -23803,9 +23913,6 @@ class Mirage_F1EQ(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -23913,15 +24020,6 @@ class Mirage_F1EQ(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -24085,39 +24183,6 @@ class Mirage_F1EQ(PlaneType):
                 4: "18",
             },
         ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
             control="editbox",
@@ -24205,8 +24270,8 @@ class Mirage_F1EQ(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (3, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon4:
         SAMP_250___250_kg_GP_Bomb_LD = (4, Weapons.SAMP_250___250_kg_GP_Bomb_LD)
@@ -24271,8 +24336,8 @@ class Mirage_F1EQ(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (5, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon6:
         SAMP_125___125_kg_GP_Bomb_LD = (6, Weapons.SAMP_125___125_kg_GP_Bomb_LD)
@@ -24396,9 +24461,6 @@ class Mirage_F1ED(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -24506,15 +24568,6 @@ class Mirage_F1ED(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -24678,39 +24731,6 @@ class Mirage_F1ED(PlaneType):
                 4: "18",
             },
         ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
             control="editbox",
@@ -24798,8 +24818,8 @@ class Mirage_F1ED(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (3, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon4:
         SAMP_250___250_kg_GP_Bomb_LD = (4, Weapons.SAMP_250___250_kg_GP_Bomb_LD)
@@ -24864,8 +24884,8 @@ class Mirage_F1ED(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (5, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon6:
         SAMP_125___125_kg_GP_Bomb_LD = (6, Weapons.SAMP_125___125_kg_GP_Bomb_LD)
@@ -24989,9 +25009,6 @@ class Mirage_F1EDA(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -25099,15 +25116,6 @@ class Mirage_F1EDA(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -25270,39 +25278,6 @@ class Mirage_F1EDA(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -25572,9 +25547,6 @@ class Mirage_F1CR(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -25682,15 +25654,6 @@ class Mirage_F1CR(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -25853,39 +25816,6 @@ class Mirage_F1CR(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -26142,9 +26072,6 @@ class Mirage_F1CT(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
     }
 
@@ -26252,15 +26179,6 @@ class Mirage_F1CT(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -26423,39 +26341,6 @@ class Mirage_F1CT(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -26712,9 +26597,6 @@ class Mirage_F1B(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "SoloFlight": False,
         "NetCrewControlPriority": 1,
@@ -26824,15 +26706,6 @@ class Mirage_F1B(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -27007,39 +26880,6 @@ class Mirage_F1B(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -27311,9 +27151,6 @@ class Mirage_F1BE(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "IFFMode4Disabled": 1,
         "SoloFlight": False,
@@ -27424,15 +27261,6 @@ class Mirage_F1BE(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -27615,39 +27443,6 @@ class Mirage_F1BE(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -27971,9 +27766,6 @@ class Mirage_F1BQ(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "SoloFlight": False,
         "NetCrewControlPriority": 1,
@@ -28083,15 +27875,6 @@ class Mirage_F1BQ(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -28267,39 +28050,6 @@ class Mirage_F1BQ(PlaneType):
                 4: "18",
             },
         ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
             control="editbox",
@@ -28407,8 +28157,8 @@ class Mirage_F1BQ(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (3, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon4:
         SAMP_250___250_kg_GP_Bomb_LD = (4, Weapons.SAMP_250___250_kg_GP_Bomb_LD)
@@ -28473,8 +28223,8 @@ class Mirage_F1BQ(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (5, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon6:
         SAMP_125___125_kg_GP_Bomb_LD = (6, Weapons.SAMP_125___125_kg_GP_Bomb_LD)
@@ -28598,9 +28348,6 @@ class Mirage_F1BD(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "SoloFlight": False,
         "NetCrewControlPriority": 1,
@@ -28710,15 +28457,6 @@ class Mirage_F1BD(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -28894,39 +28632,6 @@ class Mirage_F1BD(PlaneType):
                 4: "18",
             },
         ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
             control="editbox",
@@ -29034,8 +28739,8 @@ class Mirage_F1BD(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (3, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon4:
         SAMP_250___250_kg_GP_Bomb_LD = (4, Weapons.SAMP_250___250_kg_GP_Bomb_LD)
@@ -29100,8 +28805,8 @@ class Mirage_F1BD(PlaneType):
         GBU_10___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         S530F = (5, Weapons.S530F)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
 
     class Pylon6:
         SAMP_125___125_kg_GP_Bomb_LD = (6, Weapons.SAMP_125___125_kg_GP_Bomb_LD)
@@ -29225,9 +28930,6 @@ class Mirage_F1DDA(PlaneType):
         "GunBurstSettings": 1,
         "RocketSalvoF1": 1,
         "RocketSalvoF4": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
         "IFFMode2Code": None,
         "SoloFlight": False,
         "NetCrewControlPriority": 1,
@@ -29337,15 +29039,6 @@ class Mirage_F1DDA(PlaneType):
                 x_3 = 2
                 x_6 = 3
                 x_18 = 4
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
 
         class IFFMode2Code:
             id = "IFFMode2Code"
@@ -29520,39 +29213,6 @@ class Mirage_F1DDA(PlaneType):
                 3: "6",
                 4: "18",
             },
-        ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code 2nd dgt GBU, 1x11",
-            player_only=True,
-            minimum=5,
-            maximum=7,
-            default=6,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code 3rd dgt GBU, 11x1",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code 4th dgt GBU, 111x",
-            player_only=True,
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-            w_ctrl=75,
         ),
         "IFFMode2Code": UnitPropertyDescription(
             identifier="IFFMode2Code",
@@ -29789,8 +29449,8 @@ class Su_34(PlaneType):
         R_77__AA_12_Adder____Active_Rdr = (2, Weapons.R_77__AA_12_Adder____Active_Rdr)
 
     class Pylon3:
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (3, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (3, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (3, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -29826,8 +29486,8 @@ class Su_34(PlaneType):
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
 
     class Pylon4:
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (4, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (4, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (4, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (4, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (4, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -29871,8 +29531,8 @@ class Su_34(PlaneType):
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (5, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
         R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (5, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (5, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (5, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (5, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (5, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -29944,8 +29604,8 @@ class Su_34(PlaneType):
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (8, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
         R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (8, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (8, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (8, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (8, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -29968,8 +29628,8 @@ class Su_34(PlaneType):
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
 
     class Pylon9:
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (9, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (9, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (9, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (9, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (9, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (9, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (9, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -30009,8 +29669,8 @@ class Su_34(PlaneType):
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (9, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
 
     class Pylon10:
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (10, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (10, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (10, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (10, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (10, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (10, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (10, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -30388,6 +30048,7 @@ plane_map = {
     "Christen Eagle II": Christen_Eagle_II,
     "F-15ESE": F_15ESE,
     "F-16C_50": F_16C_50,
+    "F-4E-45MC": F_4E_45MC,
     "F-5E": F_5E,
     "F-5E-3": F_5E_3,
     "F-86F Sabre": F_86F_Sabre,

--- a/dcs/statics.py
+++ b/dcs/statics.py
@@ -462,6 +462,618 @@ class Fortification:
         shape_name = "barrelofbeer_support"
         rate = 5
 
+    class AM32a_60_01(unittype.StaticType):
+        id = "AM32a-60_01"
+        name = "M92 AM32a-60-01"
+        shape_name = "M92_AM32a-60_01"
+        rate = 1
+
+    class AM32a_60_02(unittype.StaticType):
+        id = "AM32a-60_02"
+        name = "M92 AM32a-60-02"
+        shape_name = "M92_AM32a-60_02"
+        rate = 1
+
+    class APFC_fuel(unittype.StaticType):
+        id = "APFC fuel"
+        name = "M92 APFC fuel"
+        shape_name = "M92_APFCfuel"
+        rate = 1
+
+    class B600(unittype.StaticType):
+        id = "B600"
+        name = "M92 B600"
+        shape_name = "M92_B600"
+        rate = 1
+
+    class Barrier_A(unittype.StaticType):
+        id = "Barrier A"
+        name = "M92 Barrier A"
+        shape_name = "M92_BarrierA"
+        rate = 1
+
+    class Barrier_B(unittype.StaticType):
+        id = "Barrier B"
+        name = "M92 Barrier B"
+        shape_name = "M92_BarrierB"
+        rate = 1
+
+    class Barrier_C(unittype.StaticType):
+        id = "Barrier C"
+        name = "M92 Barrier C"
+        shape_name = "M92_BarrierC"
+        rate = 1
+
+    class Barrier_D(unittype.StaticType):
+        id = "Barrier D"
+        name = "M92 Barrier D"
+        shape_name = "M92_BarrierD"
+        rate = 1
+
+    class BoomBarrier_open(unittype.StaticType):
+        id = "BoomBarrier_open"
+        name = "M92 Boom Barrier open"
+        shape_name = "M92_BoomBarrier_open"
+        rate = 1
+
+    class BoomBarrier_closed(unittype.StaticType):
+        id = "BoomBarrier_closed"
+        name = "M92 Boom Barrier closed"
+        shape_name = "M92_BoomBarrier_closed"
+        rate = 1
+
+    class Building01_PBR(unittype.StaticType):
+        id = "Building01_PBR"
+        name = "M92 Building01 PBR"
+        shape_name = "M92_Building01_PBR"
+        rate = 1
+
+    class Building02_PBR(unittype.StaticType):
+        id = "Building02_PBR"
+        name = "M92 Building02 PBR"
+        shape_name = "M92_Building02_PBR"
+        rate = 1
+
+    class Building03_PBR(unittype.StaticType):
+        id = "Building03_PBR"
+        name = "M92 Building03 PBR"
+        shape_name = "M92_Building03_PBR"
+        rate = 1
+
+    class Building04_PBR(unittype.StaticType):
+        id = "Building04_PBR"
+        name = "M92 Building04 PBR"
+        shape_name = "M92_Building04_PBR"
+        rate = 1
+
+    class Building05_PBR(unittype.StaticType):
+        id = "Building05_PBR"
+        name = "M92 Building05 PBR"
+        shape_name = "M92_Building05_PBR"
+        rate = 1
+
+    class Building06_PBR(unittype.StaticType):
+        id = "Building06_PBR"
+        name = "M92 Building06 PBR"
+        shape_name = "M92_Building06_PBR"
+        rate = 1
+
+    class Building07_PBR(unittype.StaticType):
+        id = "Building07_PBR"
+        name = "M92 Building07 PBR"
+        shape_name = "M92_Building07_PBR"
+        rate = 1
+
+    class Building08_PBR(unittype.StaticType):
+        id = "Building08_PBR"
+        name = "M92 Building08 PBR"
+        shape_name = "M92_Building08_PBR"
+        rate = 1
+
+    class Cargo01(unittype.StaticType):
+        id = "Cargo01"
+        name = "M92 Cargo 01"
+        shape_name = "M92_Cargo01"
+        rate = 1
+
+    class Cargo02(unittype.StaticType):
+        id = "Cargo02"
+        name = "M92 Cargo 02"
+        shape_name = "M92_Cargo02"
+        rate = 1
+
+    class Cargo03(unittype.StaticType):
+        id = "Cargo03"
+        name = "M92 Cargo 03"
+        shape_name = "M92_Cargo03"
+        rate = 1
+
+    class Cargo04(unittype.StaticType):
+        id = "Cargo04"
+        name = "M92 Cargo 04"
+        shape_name = "M92_Cargo04"
+        rate = 1
+
+    class Cargo05(unittype.StaticType):
+        id = "Cargo05"
+        name = "M92 Cargo 05"
+        shape_name = "M92_Cargo05"
+        rate = 1
+
+    class Cargo06(unittype.StaticType):
+        id = "Cargo06"
+        name = "M92 Cargo 06"
+        shape_name = "M92_Cargo06"
+        rate = 1
+
+    class Camouflage01(unittype.StaticType):
+        id = "Camouflage01"
+        name = "M92 Camouflage 01"
+        shape_name = "M92_Camouflage01"
+        rate = 1
+
+    class Camouflage02(unittype.StaticType):
+        id = "Camouflage02"
+        name = "M92 Camouflage 02"
+        shape_name = "M92_Camouflage02"
+        rate = 1
+
+    class Camouflage03(unittype.StaticType):
+        id = "Camouflage03"
+        name = "M92 Camouflage 03"
+        shape_name = "M92_Camouflage03"
+        rate = 1
+
+    class Camouflage04(unittype.StaticType):
+        id = "Camouflage04"
+        name = "M92 Camouflage 04"
+        shape_name = "M92_Camouflage04"
+        rate = 1
+
+    class Camouflage05(unittype.StaticType):
+        id = "Camouflage05"
+        name = "M92 Camouflage 05"
+        shape_name = "M92_Camouflage05"
+        rate = 1
+
+    class Camouflage06(unittype.StaticType):
+        id = "Camouflage06"
+        name = "M92 Camouflage 06"
+        shape_name = "M92_Camouflage06"
+        rate = 1
+
+    class Camouflage07(unittype.StaticType):
+        id = "Camouflage07"
+        name = "M92 Camouflage 07"
+        shape_name = "M92_Camouflage07"
+        rate = 1
+
+    class Cone01(unittype.StaticType):
+        id = "Cone01"
+        name = "M92 Cone 01"
+        shape_name = "M92_Cone01"
+        rate = 1
+
+    class Cone02(unittype.StaticType):
+        id = "Cone02"
+        name = "M92 Cone 02"
+        shape_name = "M92_Cone02"
+        rate = 1
+
+    class Container_10ft(unittype.StaticType):
+        id = "Container_10ft"
+        name = "M92 Container 10ft"
+        shape_name = "M92_Container_10ft"
+        rate = 1
+
+    class Container_20ft(unittype.StaticType):
+        id = "Container_20ft"
+        name = "M92 Container 20ft"
+        shape_name = "M92_Container_20ft"
+        rate = 1
+
+    class Container_40ft(unittype.StaticType):
+        id = "Container_40ft"
+        name = "M92 Container 40ft"
+        shape_name = "M92_Container_40ft"
+        rate = 1
+
+    class Container_watchtower(unittype.StaticType):
+        id = "Container_watchtower"
+        name = "M92 Container watchtower"
+        shape_name = "M92_Container_watchtower"
+        rate = 1
+
+    class Container_watchtower_lights(unittype.StaticType):
+        id = "Container_watchtower_lights"
+        name = "M92 Container watchtower lights"
+        shape_name = "M92_Container_watchtower_lights"
+        rate = 1
+
+    class Container_office(unittype.StaticType):
+        id = "Container_office"
+        name = "M92 Container office"
+        shape_name = "M92_Container_office"
+        rate = 1
+
+    class Container_generator(unittype.StaticType):
+        id = "Container_generator"
+        name = "M92 Container generator"
+        shape_name = "M92_Container_generator"
+        rate = 1
+
+    class ElevatedPlatform_down(unittype.StaticType):
+        id = "ElevatedPlatform_down"
+        name = "M92 Elevated Platform down"
+        shape_name = "M92_ElevatedPlatform_down"
+        rate = 1
+
+    class ElevatedPlatform_up(unittype.StaticType):
+        id = "ElevatedPlatform_up"
+        name = "M92 Elevated Platform up"
+        shape_name = "M92_ElevatedPlatform_up"
+        rate = 1
+
+    class FireExtinguisher01(unittype.StaticType):
+        id = "FireExtinguisher01"
+        name = "M92 Fire Extinguisher 01"
+        shape_name = "M92_FireExtinguisher01"
+        rate = 1
+
+    class FireExtinguisher02(unittype.StaticType):
+        id = "FireExtinguisher02"
+        name = "M92 Fire Extinguisher 02"
+        shape_name = "M92_FireExtinguisher02"
+        rate = 1
+
+    class FireExtinguisher03(unittype.StaticType):
+        id = "FireExtinguisher03"
+        name = "M92 Fire Extinguisher 03"
+        shape_name = "M92_FireExtinguisher03"
+        rate = 1
+
+    class HESCO_generator(unittype.StaticType):
+        id = "HESCO_generator"
+        name = "M92 HESCO generator"
+        shape_name = "M92_HESCO_generator"
+        rate = 1
+
+    class HESCO_post_1(unittype.StaticType):
+        id = "HESCO_post_1"
+        name = "M92 HESCO post 1"
+        shape_name = "M92_HESCO_post_1"
+        rate = 1
+
+    class HESCO_wallperimeter_1(unittype.StaticType):
+        id = "HESCO_wallperimeter_1"
+        name = "M92 HESCO wallperimeter 1"
+        shape_name = "M92_HESCO_wallperimeter_1"
+        rate = 1
+
+    class HESCO_wallperimeter_2(unittype.StaticType):
+        id = "HESCO_wallperimeter_2"
+        name = "M92 HESCO wallperimeter 2"
+        shape_name = "M92_HESCO_wallperimeter_2"
+        rate = 1
+
+    class HESCO_wallperimeter_3(unittype.StaticType):
+        id = "HESCO_wallperimeter_3"
+        name = "M92 HESCO wallperimeter 3"
+        shape_name = "M92_HESCO_wallperimeter_3"
+        rate = 1
+
+    class HESCO_wallperimeter_4(unittype.StaticType):
+        id = "HESCO_wallperimeter_4"
+        name = "M92 HESCO wallperimeter 4"
+        shape_name = "M92_HESCO_wallperimeter_4"
+        rate = 1
+
+    class HESCO_wallperimeter_5(unittype.StaticType):
+        id = "HESCO_wallperimeter_5"
+        name = "M92 HESCO wallperimeter 5"
+        shape_name = "M92_HESCO_wallperimeter_5"
+        rate = 1
+
+    class HESCO_watchtower_1(unittype.StaticType):
+        id = "HESCO_watchtower_1"
+        name = "M92 HESCO watchtower 1"
+        shape_name = "M92_HESCO_watchtower_1"
+        rate = 1
+
+    class HESCO_watchtower_2(unittype.StaticType):
+        id = "HESCO_watchtower_2"
+        name = "M92 HESCO watchtower 2"
+        shape_name = "M92_HESCO_watchtower_2"
+        rate = 1
+
+    class HESCO_watchtower_3(unittype.StaticType):
+        id = "HESCO_watchtower_3"
+        name = "M92 HESCO watchtower 3"
+        shape_name = "M92_HESCO_watchtower_3"
+        rate = 1
+
+    class Jerrycan(unittype.StaticType):
+        id = "Jerrycan"
+        name = "M92 Jerrycan"
+        shape_name = "M92_Jerrycan"
+        rate = 1
+
+    class Ladder(unittype.StaticType):
+        id = "Ladder"
+        name = "M92 Ladder"
+        shape_name = "M92_Ladder"
+        rate = 1
+
+    class LHD_LHA(unittype.StaticType):
+        id = "LHD_LHA"
+        name = "M92 LHD LHA"
+        shape_name = "M92_LHD_LHA"
+        rate = 1
+
+    class M32_10C_01(unittype.StaticType):
+        id = "M32-10C_01"
+        name = "M92 M32-10C 01"
+        shape_name = "M92_M32-10C_01"
+        rate = 1
+
+    class M32_10C_02(unittype.StaticType):
+        id = "M32-10C_02"
+        name = "M92 M32-10C 02"
+        shape_name = "M92_M32-10C_02"
+        rate = 1
+
+    class M32_10C_03(unittype.StaticType):
+        id = "M32-10C_03"
+        name = "M92 M32-10C 03"
+        shape_name = "M92_M32-10C_03"
+        rate = 1
+
+    class M32_10C_04(unittype.StaticType):
+        id = "M32-10C_04"
+        name = "M92 M32-10C 04"
+        shape_name = "M92_M32-10C_04"
+        rate = 1
+
+    class MJ_1_01(unittype.StaticType):
+        id = "MJ-1_01"
+        name = "M92 MJ-1 01"
+        shape_name = "M92_MJ-1_01"
+        rate = 1
+
+    class MJ_1_02(unittype.StaticType):
+        id = "MJ-1_02"
+        name = "M92 MJ-1 02"
+        shape_name = "M92_MJ-1_02"
+        rate = 1
+
+    class NF_2_LightOn(unittype.StaticType):
+        id = "NF-2_LightOn"
+        name = "M92 NF-2 LightOn"
+        shape_name = "M92_NF-2_LightOn"
+        rate = 1
+
+    class NF_2_LightOff01(unittype.StaticType):
+        id = "NF-2_LightOff01"
+        name = "M92 NF-2 LightOff 01"
+        shape_name = "M92_NF-2_LightOff01"
+        rate = 1
+
+    class NF_2_LightOff02(unittype.StaticType):
+        id = "NF-2_LightOff02"
+        name = "M92 NF-2 LightOff 02"
+        shape_name = "M92_NF-2_LightOff02"
+        rate = 1
+
+    class Oil_Barrel(unittype.StaticType):
+        id = "Oil Barrel"
+        name = "M92 Oil barrel"
+        shape_name = "M92_Oilbarrel"
+        rate = 1
+
+    class Pile_of_Woods(unittype.StaticType):
+        id = "Pile of Woods"
+        name = "M92 Pile of woods"
+        shape_name = "M92_Pileofwoods"
+        rate = 1
+
+    class P20_01(unittype.StaticType):
+        id = "P20_01"
+        name = "M92 P20 01"
+        shape_name = "M92_P20_01"
+        rate = 1
+
+    class Revetment_x4(unittype.StaticType):
+        id = "Revetment_x4"
+        name = "M92 Revetment x4"
+        shape_name = "M92_Revetment_x4"
+        rate = 1
+
+    class Revetment_x8(unittype.StaticType):
+        id = "Revetment_x8"
+        name = "M92 Revetment x8"
+        shape_name = "M92_Revetment_x8"
+        rate = 1
+
+    class R11_volvo(unittype.StaticType):
+        id = "r11_volvo"
+        name = "M92 R11 Volvo"
+        shape_name = "M92_r11_volvo"
+        rate = 1
+
+    class Sandbag_01(unittype.StaticType):
+        id = "Sandbag_01"
+        name = "M92 Sandbag 01"
+        shape_name = "M92_Sandbag_01"
+        rate = 1
+
+    class Sandbag_02(unittype.StaticType):
+        id = "Sandbag_02"
+        name = "M92 Sandbag 02"
+        shape_name = "M92_Sandbag_02"
+        rate = 1
+
+    class Sandbag_03(unittype.StaticType):
+        id = "Sandbag_03"
+        name = "M92 Sandbag 03"
+        shape_name = "M92_Sandbag_03"
+        rate = 1
+
+    class Sandbag_04(unittype.StaticType):
+        id = "Sandbag_04"
+        name = "M92 Sandbag 04"
+        shape_name = "M92_Sandbag_04"
+        rate = 1
+
+    class Sandbag_05(unittype.StaticType):
+        id = "Sandbag_05"
+        name = "M92 Sandbag 05"
+        shape_name = "M92_Sandbag_05"
+        rate = 1
+
+    class Sandbag_06(unittype.StaticType):
+        id = "Sandbag_06"
+        name = "M92 Sandbag 06"
+        shape_name = "M92_Sandbag_06"
+        rate = 1
+
+    class Sandbag_07(unittype.StaticType):
+        id = "Sandbag_07"
+        name = "M92 Sandbag 07"
+        shape_name = "M92_Sandbag_07"
+        rate = 1
+
+    class Sandbag_08(unittype.StaticType):
+        id = "Sandbag_08"
+        name = "M92 Sandbag 08"
+        shape_name = "M92_Sandbag_08"
+        rate = 1
+
+    class Sandbag_09(unittype.StaticType):
+        id = "Sandbag_09"
+        name = "M92 Sandbag 09"
+        shape_name = "M92_Sandbag_09"
+        rate = 1
+
+    class Sandbag_10(unittype.StaticType):
+        id = "Sandbag_10"
+        name = "M92 Sandbag 10"
+        shape_name = "M92_Sandbag_10"
+        rate = 1
+
+    class Sandbag_11(unittype.StaticType):
+        id = "Sandbag_11"
+        name = "M92 Sandbag 11"
+        shape_name = "M92_Sandbag_11"
+        rate = 1
+
+    class Sandbag_12(unittype.StaticType):
+        id = "Sandbag_12"
+        name = "M92 Sandbag 12"
+        shape_name = "M92_Sandbag_12"
+        rate = 1
+
+    class Sandbag_13(unittype.StaticType):
+        id = "Sandbag_13"
+        name = "M92 Sandbag 13"
+        shape_name = "M92_Sandbag_13"
+        rate = 1
+
+    class Sandbag_15(unittype.StaticType):
+        id = "Sandbag_15"
+        name = "M92 Sandbag 15"
+        shape_name = "M92_Sandbag_15"
+        rate = 1
+
+    class Sandbag_16(unittype.StaticType):
+        id = "Sandbag_16"
+        name = "M92 Sandbag 16"
+        shape_name = "M92_Sandbag_16"
+        rate = 1
+
+    class Sandbag_17(unittype.StaticType):
+        id = "Sandbag_17"
+        name = "M92 Sandbag 17"
+        shape_name = "M92_Sandbag_17"
+        rate = 1
+
+    class Shelter01(unittype.StaticType):
+        id = "Shelter01"
+        name = "M92 Shelter 01"
+        shape_name = "M92_Shelter01"
+        rate = 1
+
+    class Shelter02(unittype.StaticType):
+        id = "Shelter02"
+        name = "M92 Shelter 02"
+        shape_name = "M92_Shelter02"
+        rate = 1
+
+    class TugHarlan(unittype.StaticType):
+        id = "TugHarlan"
+        name = "M92 Tug Harlan"
+        shape_name = "M92_TugHarlan"
+        rate = 1
+
+    class Tent05(unittype.StaticType):
+        id = "Tent05"
+        name = "M92 Tent 05"
+        shape_name = "M92_Tent05"
+        rate = 1
+
+    class Tent04(unittype.StaticType):
+        id = "Tent04"
+        name = "M92 Tent 04"
+        shape_name = "M92_Tent04"
+        rate = 1
+
+    class Tent03(unittype.StaticType):
+        id = "Tent03"
+        name = "M92 Tent 03"
+        shape_name = "M92_Tent03"
+        rate = 1
+
+    class Tent02(unittype.StaticType):
+        id = "Tent02"
+        name = "M92 Tent 02"
+        shape_name = "M92_Tent02"
+        rate = 1
+
+    class Tent01(unittype.StaticType):
+        id = "Tent01"
+        name = "M92 Tent 01"
+        shape_name = "M92_Tent01"
+        rate = 1
+
+    class Toolbox01(unittype.StaticType):
+        id = "Toolbox01"
+        name = "M92 Toolbox 01"
+        shape_name = "M92_Toolbox01"
+        rate = 1
+
+    class Toolbox02(unittype.StaticType):
+        id = "Toolbox02"
+        name = "M92 Toolbox 02"
+        shape_name = "M92_Toolbox02"
+        rate = 1
+
+    class Twall_x1(unittype.StaticType):
+        id = "Twall_x1"
+        name = "M92 Twall x1"
+        shape_name = "M92_Twall_x1"
+        rate = 1
+
+    class Twall_x6(unittype.StaticType):
+        id = "Twall_x6"
+        name = "M92 Twall x6"
+        shape_name = "M92_Twall_x6"
+        rate = 1
+
+    class Twall_x6_3mts(unittype.StaticType):
+        id = "Twall_x6_3mts"
+        name = "M92 Twall x6 3mts"
+        shape_name = "M92_Twall_x6_3mts"
+        rate = 1
+
     class Orca(unittype.StaticType):
         id = "Orca"
         name = "Orca Whale"
@@ -526,6 +1138,30 @@ class Fortification:
         id = "offshore WindTurbine2"
         name = "Offshore Wind Turbine 2"
         shape_name = "offshore_windturbine2"
+        rate = 3
+
+    class FarpHide_small(unittype.StaticType):
+        id = "FarpHide_small"
+        name = "FARP Hide Single Small"
+        shape_name = "FarpHide_small"
+        rate = 3
+
+    class FarpHide_Med(unittype.StaticType):
+        id = "FarpHide_Med"
+        name = "FARP Hide Single Med"
+        shape_name = "FarpHide_Med"
+        rate = 3
+
+    class FarpHide_Dsmall(unittype.StaticType):
+        id = "FarpHide_Dsmall"
+        name = "FARP Hide Double Small"
+        shape_name = "FarpHide_Dsmall"
+        rate = 3
+
+    class FarpHide_Dmed(unittype.StaticType):
+        id = "FarpHide_Dmed"
+        name = "FARP Hide Double Med"
+        shape_name = "FarpHide_Dmed"
         rate = 3
 
     class Container_40ft(unittype.StaticType):
@@ -785,6 +1421,108 @@ fortification_map = {
     "Black_Tyre_WF": Fortification.Black_Tyre_WF,
     "Windsock": Fortification.Windsock,
     "Beer Bomb": Fortification.Beer_Bomb,
+    "AM32a-60_01": Fortification.AM32a_60_01,
+    "AM32a-60_02": Fortification.AM32a_60_02,
+    "APFC fuel": Fortification.APFC_fuel,
+    "B600": Fortification.B600,
+    "Barrier A": Fortification.Barrier_A,
+    "Barrier B": Fortification.Barrier_B,
+    "Barrier C": Fortification.Barrier_C,
+    "Barrier D": Fortification.Barrier_D,
+    "BoomBarrier_open": Fortification.BoomBarrier_open,
+    "BoomBarrier_closed": Fortification.BoomBarrier_closed,
+    "Building01_PBR": Fortification.Building01_PBR,
+    "Building02_PBR": Fortification.Building02_PBR,
+    "Building03_PBR": Fortification.Building03_PBR,
+    "Building04_PBR": Fortification.Building04_PBR,
+    "Building05_PBR": Fortification.Building05_PBR,
+    "Building06_PBR": Fortification.Building06_PBR,
+    "Building07_PBR": Fortification.Building07_PBR,
+    "Building08_PBR": Fortification.Building08_PBR,
+    "Cargo01": Fortification.Cargo01,
+    "Cargo02": Fortification.Cargo02,
+    "Cargo03": Fortification.Cargo03,
+    "Cargo04": Fortification.Cargo04,
+    "Cargo05": Fortification.Cargo05,
+    "Cargo06": Fortification.Cargo06,
+    "Camouflage01": Fortification.Camouflage01,
+    "Camouflage02": Fortification.Camouflage02,
+    "Camouflage03": Fortification.Camouflage03,
+    "Camouflage04": Fortification.Camouflage04,
+    "Camouflage05": Fortification.Camouflage05,
+    "Camouflage06": Fortification.Camouflage06,
+    "Camouflage07": Fortification.Camouflage07,
+    "Cone01": Fortification.Cone01,
+    "Cone02": Fortification.Cone02,
+    "Container_10ft": Fortification.Container_10ft,
+    "Container_20ft": Fortification.Container_20ft,
+    "Container_40ft": Fortification.Container_40ft,
+    "Container_watchtower": Fortification.Container_watchtower,
+    "Container_watchtower_lights": Fortification.Container_watchtower_lights,
+    "Container_office": Fortification.Container_office,
+    "Container_generator": Fortification.Container_generator,
+    "ElevatedPlatform_down": Fortification.ElevatedPlatform_down,
+    "ElevatedPlatform_up": Fortification.ElevatedPlatform_up,
+    "FireExtinguisher01": Fortification.FireExtinguisher01,
+    "FireExtinguisher02": Fortification.FireExtinguisher02,
+    "FireExtinguisher03": Fortification.FireExtinguisher03,
+    "HESCO_generator": Fortification.HESCO_generator,
+    "HESCO_post_1": Fortification.HESCO_post_1,
+    "HESCO_wallperimeter_1": Fortification.HESCO_wallperimeter_1,
+    "HESCO_wallperimeter_2": Fortification.HESCO_wallperimeter_2,
+    "HESCO_wallperimeter_3": Fortification.HESCO_wallperimeter_3,
+    "HESCO_wallperimeter_4": Fortification.HESCO_wallperimeter_4,
+    "HESCO_wallperimeter_5": Fortification.HESCO_wallperimeter_5,
+    "HESCO_watchtower_1": Fortification.HESCO_watchtower_1,
+    "HESCO_watchtower_2": Fortification.HESCO_watchtower_2,
+    "HESCO_watchtower_3": Fortification.HESCO_watchtower_3,
+    "Jerrycan": Fortification.Jerrycan,
+    "Ladder": Fortification.Ladder,
+    "LHD_LHA": Fortification.LHD_LHA,
+    "M32-10C_01": Fortification.M32_10C_01,
+    "M32-10C_02": Fortification.M32_10C_02,
+    "M32-10C_03": Fortification.M32_10C_03,
+    "M32-10C_04": Fortification.M32_10C_04,
+    "MJ-1_01": Fortification.MJ_1_01,
+    "MJ-1_02": Fortification.MJ_1_02,
+    "NF-2_LightOn": Fortification.NF_2_LightOn,
+    "NF-2_LightOff01": Fortification.NF_2_LightOff01,
+    "NF-2_LightOff02": Fortification.NF_2_LightOff02,
+    "Oil Barrel": Fortification.Oil_Barrel,
+    "Pile of Woods": Fortification.Pile_of_Woods,
+    "P20_01": Fortification.P20_01,
+    "Revetment_x4": Fortification.Revetment_x4,
+    "Revetment_x8": Fortification.Revetment_x8,
+    "r11_volvo": Fortification.R11_volvo,
+    "Sandbag_01": Fortification.Sandbag_01,
+    "Sandbag_02": Fortification.Sandbag_02,
+    "Sandbag_03": Fortification.Sandbag_03,
+    "Sandbag_04": Fortification.Sandbag_04,
+    "Sandbag_05": Fortification.Sandbag_05,
+    "Sandbag_06": Fortification.Sandbag_06,
+    "Sandbag_07": Fortification.Sandbag_07,
+    "Sandbag_08": Fortification.Sandbag_08,
+    "Sandbag_09": Fortification.Sandbag_09,
+    "Sandbag_10": Fortification.Sandbag_10,
+    "Sandbag_11": Fortification.Sandbag_11,
+    "Sandbag_12": Fortification.Sandbag_12,
+    "Sandbag_13": Fortification.Sandbag_13,
+    "Sandbag_15": Fortification.Sandbag_15,
+    "Sandbag_16": Fortification.Sandbag_16,
+    "Sandbag_17": Fortification.Sandbag_17,
+    "Shelter01": Fortification.Shelter01,
+    "Shelter02": Fortification.Shelter02,
+    "TugHarlan": Fortification.TugHarlan,
+    "Tent05": Fortification.Tent05,
+    "Tent04": Fortification.Tent04,
+    "Tent03": Fortification.Tent03,
+    "Tent02": Fortification.Tent02,
+    "Tent01": Fortification.Tent01,
+    "Toolbox01": Fortification.Toolbox01,
+    "Toolbox02": Fortification.Toolbox02,
+    "Twall_x1": Fortification.Twall_x1,
+    "Twall_x6": Fortification.Twall_x6,
+    "Twall_x6_3mts": Fortification.Twall_x6_3mts,
     "Orca": Fortification.Orca,
     "WindTurbine": Fortification.WindTurbine,
     "WindTurbine_11": Fortification.WindTurbine_11,
@@ -796,6 +1534,10 @@ fortification_map = {
     "Nodding_Donkey_Pump": Fortification.Nodding_Donkey_Pump,
     "offshore WindTurbine": Fortification.Offshore_WindTurbine,
     "offshore WindTurbine2": Fortification.Offshore_WindTurbine2,
+    "FarpHide_small": Fortification.FarpHide_small,
+    "FarpHide_Med": Fortification.FarpHide_Med,
+    "FarpHide_Dsmall": Fortification.FarpHide_Dsmall,
+    "FarpHide_Dmed": Fortification.FarpHide_Dmed,
     "container_40ft": Fortification.Container_40ft,
     "container_20ft": Fortification.Container_20ft,
     "FlagPole": Fortification.FlagPole,

--- a/dcs/vehicles.py
+++ b/dcs/vehicles.py
@@ -106,6 +106,13 @@ class Artillery:
         air_weapon_dist = 32000
         eplrs = True
 
+    class L118_Unit(unittype.VehicleType):
+        id = "L118_Unit"
+        name = "L118 Light Artillery Gun"
+        detection_range = 500
+        threat_range = 17200
+        air_weapon_dist = 17200
+
     class HL_B8M1(unittype.VehicleType):
         id = "HL_B8M1"
         name = "MLRS HL with B8M1 80mm"
@@ -1205,7 +1212,7 @@ class Unarmed:
 
     class Trolley_bus(unittype.VehicleType):
         id = "Trolley bus"
-        name = "Bus ZIU-9 Trolley"
+        name = "ZIU-9 Trolley"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -1290,6 +1297,41 @@ class Unarmed:
     class KrAZ6322(unittype.VehicleType):
         id = "KrAZ6322"
         name = "Truck KrAZ-6322 6x6"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class TugHarlan_drivable(unittype.VehicleType):
+        id = "TugHarlan_drivable"
+        name = "M92 Tug Harlan drivable"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class B600_drivable(unittype.VehicleType):
+        id = "B600_drivable"
+        name = "M92 B600 drivable"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class MJ_1_drivable(unittype.VehicleType):
+        id = "MJ-1_drivable"
+        name = "M92 MJ-1 drivable"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class P20_drivable(unittype.VehicleType):
+        id = "P20_drivable"
+        name = "M92 P20 drivable"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class R11_volvo_drivable(unittype.VehicleType):
+        id = "r11_volvo_drivable"
+        name = "M92 R11 Volvo drivable"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -2235,6 +2277,11 @@ vehicle_map = {
     "S-300PS 40B6MD sr_19J6": AirDefence.S_300PS_40B6MD_sr_19J6,
     "S-300PS 5H63C 30H6_tr": AirDefence.S_300PS_5H63C_30H6_tr,
     "S-300PS 40B6MD sr": AirDefence.S_300PS_40B6MD_sr,
+    "TugHarlan_drivable": Unarmed.TugHarlan_drivable,
+    "B600_drivable": Unarmed.B600_drivable,
+    "MJ-1_drivable": Unarmed.MJ_1_drivable,
+    "P20_drivable": Unarmed.P20_drivable,
+    "r11_volvo_drivable": Unarmed.R11_volvo_drivable,
     "Electric locomotive": Locomotive.Electric_locomotive,
     "Locomotive": Locomotive.Locomotive,
     "Coach cargo": Carriage.Coach_cargo,
@@ -2243,6 +2290,7 @@ vehicle_map = {
     "Coach a tank yellow": Carriage.Coach_a_tank_yellow,
     "Coach a passenger": Carriage.Coach_a_passenger,
     "Coach a platform": Carriage.Coach_a_platform,
+    "L118_Unit": Artillery.L118_Unit,
     "tacr2a": Unarmed.Tacr2a,
     "LARC-V": Unarmed.LARC_V,
     "KS-19": AirDefence.KS_19,

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -19,19 +19,28 @@ class Weapons:
     AGM_122_Sidearm = {"clsid": "{AGM_122_SIDEARM}", "name": "AGM-122 Sidearm", "weight": 98.883056}
     AGM_122_Sidearm_ = {"clsid": "{LAU_7_AGM_122_SIDEARM}", "name": "AGM-122 Sidearm", "weight": 139.706336}
     AGM_122_Sidearm___light_ARM = {"clsid": "{AGM_122}", "name": "AGM-122 Sidearm - light ARM", "weight": 88}
-    AGM_12A_Bullpup___MCLOS_missile = {"clsid": "{AGM_12A}", "name": "AGM-12A Bullpup - MCLOS missile", "weight": None}
-    AGM_12B_Bullpup___MCLOS_missile = {"clsid": "{AGM_12B}", "name": "AGM-12B Bullpup - MCLOS missile", "weight": None}
+    AGM_12A_Bullpup_MCLOS_ASM__LAU_34_ = {"clsid": "{AGM_12A}", "name": "AGM-12A Bullpup MCLOS ASM (LAU-34)", "weight": 296}
+    AGM_12B_Bullpup_MCLOS_ASM__LAU_34_ = {"clsid": "{AGM_12B}", "name": "AGM-12B Bullpup MCLOS ASM (LAU-34)", "weight": 302}
+    AGM_12C_Bullpup_MCLOS_ASM = {"clsid": "{AGM_12C}", "name": "AGM-12C Bullpup MCLOS ASM", "weight": 811.5}
+    AGM_12C_Bullpup___MCLOS_missile = {"clsid": "{HB_F4E_AGM_12C}", "name": "AGM-12C Bullpup - MCLOS missile", "weight": None}
     AGM_130C_9___3000lb_TV__EO__Guided_Missile = {"clsid": "{AGM_130C_9}", "name": "AGM-130C-9 - 3000lb TV (EO) Guided Missile", "weight": None}
     AGM_154A___JSOW_CEB__CBU_type_ = {"clsid": "{AGM-154A}", "name": "AGM-154A - JSOW CEB (CBU-type)", "weight": 485}
     AGM_154B___JSOW_Anti_Armour = {"clsid": "{AGM-154B}", "name": "AGM-154B - JSOW Anti-Armour", "weight": 485}
     AGM_154C___JSOW_Unitary_BROACH = {"clsid": "{9BCC2A2B-5708-4860-B1F1-053A18442067}", "name": "AGM-154C - JSOW Unitary BROACH", "weight": 484}
-    AGM_45A_Shrike_ARM = {"clsid": "{AGM_45A}", "name": "AGM-45A Shrike ARM", "weight": 177}
-    AGM_45B_Shrike_ARM__Imp_ = {"clsid": "{3E6B632D-65EB-44D2-9501-1C2D04515404}", "name": "AGM-45B Shrike ARM (Imp)", "weight": 177}
+    AGM_45A_Shrike_ARM = {"clsid": "{AGM_45A}", "name": "AGM-45A Shrike ARM", "weight": 180}
+    AGM_45A_Shrike_ARM__LAU_34_ = {"clsid": "{LAU_34_AGM_45A}", "name": "AGM-45A Shrike ARM (LAU-34)", "weight": 219}
+    AGM_45B_Shrike_ARM = {"clsid": "{AGM_45B}", "name": "AGM-45B Shrike ARM", "weight": 185}
     AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = {"clsid": "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}", "name": "AGM-62 Walleye II - Guided Weapon Mk 5 (TV Guided)", "weight": 1061}
     AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_ = {"clsid": "{AGM_62_I}", "name": "AGM-62 Walleye I - Guided Weapon Mk 1 (TV Guided)", "weight": 510}
+    AGM_65A___Maverick_A__TV_Guided___LAU_117_ = {"clsid": "{HB_F4E_AGM-65A_LAU117}", "name": "AGM-65A - Maverick A (TV Guided) (LAU-117)", "weight": 269.5}
+    AGM_65B___Maverick_B__TV_Guided___LAU_117_ = {"clsid": "{HB_F4E_AGM-65B_LAU117}", "name": "AGM-65B - Maverick B (TV Guided) (LAU-117)", "weight": 269.5}
     AGM_65D___Maverick_D__IIR_ASM_ = {"clsid": "{444BA8AE-82A7-4345-842E-76154EFCCA47}", "name": "AGM-65D - Maverick D (IIR ASM)", "weight": 218}
+    AGM_65D___Maverick_D__IIR_ASM___LAU_117_ = {"clsid": "{HB_F4E_AGM-65D_LAU117}", "name": "AGM-65D - Maverick D (IIR ASM) (LAU-117)", "weight": 269.5}
     AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = {"clsid": "{F16A4DE0-116C-4A71-97F0-2CF85B0313EF}", "name": "AGM-65E - Maverick E (Laser ASM - Lg Whd)", "weight": 286}
+    AGM_65G___Maverick_G__IIR_ASM___Lg_Whd___LAU_117_ = {"clsid": "{HB_F4E_AGM-65G_LAU117}", "name": "AGM-65G - Maverick G (IIR ASM - Lg Whd) (LAU-117)", "weight": 360}
     AGM_65K___Maverick_K__CCD_Imp_ASM_ = {"clsid": "{69DC8AE7-8F77-427B-B8AA-B19D3F478B65}", "name": "AGM-65K - Maverick K (CCD Imp ASM)", "weight": 298}
+    AGM_78A_Standard_ARM = {"clsid": "{AGM_78A}", "name": "AGM-78A Standard ARM", "weight": 615}
+    AGM_78B_Standard_ARM = {"clsid": "{AGM_78B}", "name": "AGM-78B Standard ARM", "weight": 620}
     AGM_84A_Harpoon_ASM = {"clsid": "{8B7CADF9-4954-46B3-8CFB-93F2F5B90B03}", "name": "AGM-84A Harpoon ASM", "weight": 661.5}
     AGM_84D_Harpoon_AShM = {"clsid": "{AGM_84D}", "name": "AGM-84D Harpoon AShM", "weight": 540}
     AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = {"clsid": "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}", "name": "AGM-84E Harpoon/SLAM (Stand-Off Land-Attack Missile)", "weight": 628}
@@ -58,23 +67,30 @@ class Weapons:
     AIM_54C_Mk60__ = {"clsid": "{SHOULDER AIM_54C_Mk60 R}", "name": "AIM-54C-Mk60", "weight": 499.36}
     AIM_7E = {"clsid": "{SHOULDER AIM-7E}", "name": "AIM-7E", "weight": 284.4}
     AIM_7E_ = {"clsid": "{BELLY AIM-7E}", "name": "AIM-7E", "weight": 230}
-    AIM_7E_2_Sparrow_Semi_Active_Radar = {"clsid": "{AIM-7E}", "name": "AIM-7E-2 Sparrow Semi-Active Radar", "weight": 230}
-    AIM_7F = {"clsid": "{SHOULDER AIM-7F}", "name": "AIM-7F", "weight": 284.4}
-    AIM_7F_ = {"clsid": "{BELLY AIM-7F}", "name": "AIM-7F", "weight": 230}
+    AIM_7E_2_Sparrow_Semi_Active_Radar = {"clsid": "{AIM-7E-2}", "name": "AIM-7E-2 Sparrow Semi-Active Radar", "weight": 230}
+    AIM_7E_2_Sparrow_Semi_Active_Radar_ = {"clsid": "{HB_F4E_AIM-7E-2}", "name": "AIM-7E-2 Sparrow Semi-Active Radar", "weight": 230}
+    AIM_7E_Sparrow_Semi_Active_Radar = {"clsid": "{AIM-7E}", "name": "AIM-7E Sparrow Semi-Active Radar", "weight": 230}
+    AIM_7E_Sparrow_Semi_Active_Radar_ = {"clsid": "{HB_F4E_AIM-7E}", "name": "AIM-7E Sparrow Semi-Active Radar", "weight": 230}
+    AIM_7F = {"clsid": "{HB_F4E_AIM-7F}", "name": "AIM-7F", "weight": 230}
+    AIM_7F_ = {"clsid": "{SHOULDER AIM-7F}", "name": "AIM-7F", "weight": 284.4}
     AIM_7F_Sparrow_Semi_Active_Radar = {"clsid": "{AIM-7F}", "name": "AIM-7F Sparrow Semi-Active Radar", "weight": 231}
-    AIM_7M = {"clsid": "{SHOULDER AIM-7M}", "name": "AIM-7M", "weight": 284.4}
+    AIM_7F__ = {"clsid": "{BELLY AIM-7F}", "name": "AIM-7F", "weight": 230}
+    AIM_7M = {"clsid": "{HB_F4E_AIM-7M}", "name": "AIM-7M", "weight": 230}
     AIM_7MH = {"clsid": "{SHOULDER AIM-7MH}", "name": "AIM-7MH", "weight": 284.4}
     AIM_7MH_ = {"clsid": "{BELLY AIM-7MH}", "name": "AIM-7MH", "weight": 230}
     AIM_7MH_Sparrow_Semi_Active_Radar = {"clsid": "{AIM-7H}", "name": "AIM-7MH Sparrow Semi-Active Radar", "weight": 231}
-    AIM_7M_ = {"clsid": "{BELLY AIM-7M}", "name": "AIM-7M", "weight": 230}
+    AIM_7M_ = {"clsid": "{SHOULDER AIM-7M}", "name": "AIM-7M", "weight": 284.4}
     AIM_7M_Sparrow_Semi_Active_Radar = {"clsid": "{8D399DDA-FF81-4F14-904D-099B34FE7918}", "name": "AIM-7M Sparrow Semi-Active Radar", "weight": 231.1}
+    AIM_7M__ = {"clsid": "{BELLY AIM-7M}", "name": "AIM-7M", "weight": 230}
     AIM_7P = {"clsid": "{SHOULDER AIM-7P}", "name": "AIM-7P", "weight": 284.4}
     AIM_7P_ = {"clsid": "{BELLY AIM-7P}", "name": "AIM-7P", "weight": 230}
     AIM_7P_Sparrow_Semi_Active_Radar = {"clsid": "{AIM-7P}", "name": "AIM-7P Sparrow Semi-Active Radar", "weight": 231}
     AIM_9B_Sidewinder_IR_AAM = {"clsid": "{AIM-9B}", "name": "AIM-9B Sidewinder IR AAM", "weight": 74.39}
+    AIM_9E_Sidewinder_IR_AAM = {"clsid": "{AIM-9E}", "name": "AIM-9E Sidewinder IR AAM", "weight": 76.43}
     AIM_9JULI_Sidewinder_IR_AAM = {"clsid": "{AIM-9JULI}", "name": "AIM-9JULI Sidewinder IR AAM", "weight": 82.3}
-    AIM_9J_Sidewinder_IR_AAM = {"clsid": "{AIM-9J}", "name": "AIM-9J Sidewinder IR AAM", "weight": 74.84}
+    AIM_9J_Sidewinder_IR_AAM = {"clsid": "{AIM-9J}", "name": "AIM-9J Sidewinder IR AAM", "weight": 76.93}
     AIM_9L_Sidewinder_IR_AAM = {"clsid": "{AIM-9L}", "name": "AIM-9L Sidewinder IR AAM", "weight": 85.73}
+    AIM_9M = {"clsid": "{AIM-9M}", "name": "AIM-9M", "weight": 86.64}
     AIM_9M_Sidewinder_IR_AAM = {"clsid": "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}", "name": "AIM-9M Sidewinder IR AAM", "weight": 85.73}
     AIM_9P3_Sidewinder_IR_AAM = {"clsid": "{AIM-9P3}", "name": "AIM-9P3 Sidewinder IR AAM", "weight": 80.7}
     AIM_9P5_Sidewinder_IR_AAM = {"clsid": "{AIM-9P5}", "name": "AIM-9P5 Sidewinder IR AAM", "weight": 80.7}
@@ -84,7 +100,13 @@ class Weapons:
     AKAN_M_55_Gunpod__150_rnds_MINGR55_HE = {"clsid": "{AKAN}", "name": "AKAN M/55 Gunpod, 150 rnds MINGR55-HE", "weight": 276}
     AKAN_M_55_Gunpod__150_rnds_MINGR55_HE__no_Tracer_ = {"clsid": "{AKAN_NO_TRC}", "name": "AKAN M/55 Gunpod, 150 rnds MINGR55-HE (no Tracer)", "weight": 276}
     ALARM = {"clsid": "{E6747967-B1F0-4C77-977B-AB2E6EB0C102}", "name": "ALARM", "weight": 268}
+    ALE_40_Dispensers__120_Chaff_ = {"clsid": "{HB_ALE_40_0_120}", "name": "ALE-40 Dispensers (120 Chaff)", "weight": 0}
+    ALE_40_Dispensers__15_Flares__90_Chaff_ = {"clsid": "{HB_ALE_40_15_90}", "name": "ALE-40 Dispensers (15 Flares + 90 Chaff)", "weight": 0}
+    ALE_40_Dispensers__30_Flares_ = {"clsid": "{HB_ALE_40_30_0}", "name": "ALE-40 Dispensers (30 Flares)", "weight": 0}
+    ALE_40_Dispensers__30_Flares__60_Chaff_ = {"clsid": "{HB_ALE_40_30_60}", "name": "ALE-40 Dispensers (30 Flares + 60 Chaff)", "weight": 0}
+    ALE_40_Dispensers__Empty_ = {"clsid": "{HB_ALE_40_0_0}", "name": "ALE-40 Dispensers (Empty)", "weight": 0}
     ALQ_131___ECM_Pod = {"clsid": "{6D21ECEA-F85B-4E8D-9D51-31DC9B8AA4EF}", "name": "ALQ-131 - ECM Pod", "weight": 305}
+    ALQ_131___ECM_Pod_Rack = {"clsid": "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}", "name": "ALQ-131 - ECM Pod Rack", "weight": 330.9}
     ALQ_167__non_functional_ = {"clsid": "{F14-ALQ167}", "name": "ALQ-167 (non-functional)", "weight": 107}
     ALQ_184 = {"clsid": "ALQ_184", "name": "ALQ-184 - ECM Pod", "weight": 215}
     ALQ_184_Long = {"clsid": "ALQ_184_Long", "name": "ALQ-184 Long - ECM Pod", "weight": 286}
@@ -102,6 +124,10 @@ class Weapons:
     AN_ASQ_T50_TCTS_Pod___ACMI_Pod = {"clsid": "{AIS_ASQ_T50}", "name": "AN/ASQ-T50 TCTS Pod - ACMI Pod", "weight": 62.6}
     AN_ASQ_T50_TCTS_Pod___ACMI_Pod_ = {"clsid": "{LAU-138 wtip - TCTS L}", "name": "AN/ASQ-T50 TCTS Pod - ACMI Pod", "weight": 62.6}
     AN_ASQ_T50_TCTS_Pod___ACMI_Pod__ = {"clsid": "{LAU-138 wtip - TCTS R}", "name": "AN/ASQ-T50 TCTS Pod - ACMI Pod", "weight": 62.6}
+    AN_AVQ_23_Pave_Spike__Fast_Smart_Track____Targeting_Pod = {"clsid": "{HB_PAVE_SPIKE_FAST_TRACK}", "name": "AN/AVQ-23 Pave Spike (Fast/Smart Track) - Targeting Pod", "weight": 192}
+    AN_AVQ_23_Pave_Spike__Fast_Smart_Track____Targeting_Pod_Rack = {"clsid": "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}", "name": "AN/AVQ-23 Pave Spike (Fast/Smart Track) - Targeting Pod Rack", "weight": 217.9}
+    AN_AVQ_23_Pave_Spike___Targeting_Pod = {"clsid": "{HB_PAVE_SPIKE}", "name": "AN/AVQ-23 Pave Spike - Targeting Pod", "weight": 192}
+    AN_AVQ_23_Pave_Spike___Targeting_Pod_Rack = {"clsid": "{HB_PAVE_SPIKE_ON_ADAPTER_IN_AERO7}", "name": "AN/AVQ-23 Pave Spike - Targeting Pod Rack", "weight": 217.9}
     AN_AXQ_14_Data_Link_Pod = {"clsid": "{AN_AXQ_14}", "name": "AN/AXQ-14 Data Link Pod", "weight": 300}
     AN_M30A1___100lb_GP_Bomb_LD = {"clsid": "{AN_M30A1}", "name": "AN-M30A1 - 100lb GP Bomb LD", "weight": 45.8}
     AN_M3_Gunpod_Left = {"clsid": "{MB339_ANM3_L}", "name": "AN/M3 Gunpod Left", "weight": 75}
@@ -378,7 +404,7 @@ class Weapons:
     DIS_CM_802AKG_AI = {"clsid": "DIS_CM-802AKG_AI", "name": "CM802AKG (DIS) for AI", "weight": 765}
     DIS_C_701IR = {"clsid": "DIS_C-701IR", "name": "C-701IR", "weight": 170}
     DIS_C_701T = {"clsid": "DIS_C-701T", "name": "C-701T", "weight": 170}
-    DIS_C_802AK = {"clsid": "DIS_C-802AK", "name": "C802AK (DIS)", "weight": 765}
+    DIS_C_802AK = {"clsid": "DIS_C-802AK", "name": "C802AK", "weight": 765}
     DIS_DF4A_KD20 = {"clsid": "DIS_DF4A_KD20", "name": "KD-20", "weight": 1750}
     DIS_DF4B_YJ12 = {"clsid": "DIS_DF4B_YJ12", "name": "YJ-12", "weight": 1800}
     DIS_GB6 = {"clsid": "DIS_GB6", "name": "GB-6", "weight": 672}
@@ -532,12 +558,13 @@ class Weapons:
     GBU_12___4 = {"clsid": "{CFT_L_GBU_12_x_4}", "name": "GBU-12 * 4", "weight": 1100}
     GBU_12___4_ = {"clsid": "{CFT_R_GBU_12_x_4}", "name": "GBU-12 * 4", "weight": 1100}
     GBU_12___500lb_Laser_Guided_Bomb = {"clsid": "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}", "name": "GBU-12 - 500lb Laser Guided Bomb", "weight": 277}
+    GBU_15_V1___2000_lb_TV_Guided_Bomb = {"clsid": "{GBU-15V1}", "name": "GBU-15 V1 - 2000 lb TV Guided Bomb", "weight": 1136}
     GBU_15_V_31_B___2000lb_TV__EO__Guided_Bomb = {"clsid": "{GBU_15_V_31B}", "name": "GBU-15(V)31/B - 2000lb TV (EO) Guided Bomb", "weight": 1125}
     GBU_16 = {"clsid": "{BRU-32 GBU-16}", "name": "GBU-16", "weight": 621.38}
     GBU_16___1000lb_Laser_Guided_Bomb = {"clsid": "{0D33DDAE-524F-4A4E-B5B8-621754FE3ADE}", "name": "GBU-16 - 1000lb Laser Guided Bomb", "weight": 513}
     GBU_24 = {"clsid": "{BRU-32 GBU-24}", "name": "GBU-24", "weight": 1107.38}
-    GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = {"clsid": "{GBU-24}", "name": "GBU-24A/B Paveway III - 2000lb Laser Guided Bomb", "weight": 1087}
-    GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = {"clsid": "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}", "name": "GBU-24 Paveway III - 2000lb Laser Guided Bomb", "weight": 1087}
+    GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb = {"clsid": "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}", "name": "GBU-24A/B Paveway III - 2000lb Laser Guided Bomb", "weight": 1087}
+    GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb = {"clsid": "{GBU-24}", "name": "GBU-24B/B Paveway III - 2000lb Laser Guided Bomb", "weight": 1087}
     GBU_27___2 = {"clsid": "{CFT_R_GBU_27_x_2}", "name": "GBU-27 * 2", "weight": 1982}
     GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = {"clsid": "{EF0A9419-01D6-473B-99A3-BEBDB923B14D}", "name": "GBU-27 - 2000lb Laser Guided Penetrator Bomb", "weight": 1200}
     GBU_28___5000lb_Laser_Guided_Penetrator_Bomb = {"clsid": "{F06B775B-FC70-44B5-8A9F-5B5E2EB839C7}", "name": "GBU-28 - 5000lb Laser Guided Penetrator Bomb", "weight": 2130}
@@ -559,6 +586,7 @@ class Weapons:
     GBU_54B___3 = {"clsid": "{CFT_L_GBU_54_x_3}", "name": "GBU-54B * 3", "weight": 759}
     GBU_54B___3_ = {"clsid": "{CFT_R_GBU_54_x_3}", "name": "GBU-54B * 3", "weight": 759}
     GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = {"clsid": "{GBU_54_V_1B}", "name": "GBU-54(V)1/B - LJDAM, 500lb Laser & GPS Guided Bomb LD", "weight": 253}
+    GBU_8_HOBOS___2000_lb_TV_Guided_Bomb = {"clsid": "{HB_F4E_GBU_8}", "name": "GBU-8 HOBOS - 2000 lb TV Guided Bomb", "weight": 1027}
     GB_6 = {"clsid": "{GB-6}", "name": "GB-6", "weight": 620}
     GB_6_HE = {"clsid": "{GB-6-HE}", "name": "GB-6-HE", "weight": 620}
     GB_6_SFW = {"clsid": "{GB-6-SFW}", "name": "GB-6-SFW", "weight": 620}
@@ -569,6 +597,10 @@ class Weapons:
     GIAT_M621__240x_SAPHEI_ = {"clsid": "{GIAT_M621_SAPHEI}", "name": "GIAT M621 (240x SAPHEI)", "weight": 129.26}
     GUV_VOG = {"clsid": "GUV_VOG", "name": "GUV-8700 w AP-30 - 30mm Grenade Launcher", "weight": 274}
     GUV_YakB_GSHP = {"clsid": "GUV_YakB_GSHP", "name": "GUV-8700 w 1x12.7 mm & 2x7.62 mm Rotary HMG", "weight": 452}
+    HB_F4E_CBU_1_A_pod___19_x_tubes_of_Bomblets_BLU_3B_x_27__HE = {"clsid": "{HB_F4E_CBU-1/A}", "name": "HB_F4E_CBU-1/A pod - 19 x tubes of Bomblets BLU-3B x 27, HE", "weight": 329.46201328}
+    HB_F4E_CBU_2B_A_pod___19_x_tubes_of_Bomblets_BLU_3B_x_22__HE = {"clsid": "{HB_F4E_CBU-2B/A}", "name": "HB_F4E_CBU-2B/A pod - 19 x tubes of Bomblets BLU-3B x 22, HE", "weight": 382.89515088}
+    HB_F4E_CBU_2_A_pod___19_x_tubes_of_Bomblets_BLU_3B_x_19__HE = {"clsid": "{HB_F4E_CBU-2/A}", "name": "HB_F4E_CBU-2/A pod - 19 x tubes of Bomblets BLU-3B x 19, HE", "weight": 338.16644376}
+    High_Performance_Centerline_Tank_600_gallons = {"clsid": "{F4_HIGH_PERFORMANCE_CENTERLINE_600_GAL}", "name": "High Performance Centerline Tank 600 gallons", "weight": 1970.1}
     HSAB_with_6_x_AGM_84 = {"clsid": "{HSAB-6xAGM-84}", "name": "HSAB with 6 x AGM-84", "weight": 5054.6}
     HSAB_with_6_x_Mk_84___2000lb_GP_Bombs_LD = {"clsid": "{696CFFC4-0BDE-42A8-BE4B-0BE3D9DD723C}", "name": "HSAB with 6 x Mk-84 - 2000lb GP Bombs LD", "weight": 6536.6}
     HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = {"clsid": "{4CD2BB0F-5493-44EF-A927-9760350F7BA1}", "name": "HSAB with 9 x Mk-20 Rockeye - 490lbs CBUs, 247 x HEAT Bomblets", "weight": 3086.6}
@@ -594,22 +626,22 @@ class Weapons:
     KD_63B = {"clsid": "{KD_63B}", "name": "KD-63B", "weight": 2000}
     Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = {"clsid": "{12429ECF-03F0-4DF6-BCBD-5D38B6343DE1}", "name": "Kh-22 (AS-4 Kitchen) - 1000kg, AShM, IN & Act/Pas Rdr", "weight": 6800}
     Kh_23L_Grom__AS_7_Kerry____286kg__ASM__Laser_Guided = {"clsid": "{9F390892-E6F9-42C9-B84E-1136A881DCB2}", "name": "Kh-23L Grom (AS-7 Kerry) - 286kg, ASM, Laser Guided", "weight": 288}
-    Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = {"clsid": "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}", "name": "Kh-25ML (AS-10 Karen) - 300kg, ASM, Semi-Act Laser", "weight": 360}
-    Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = {"clsid": "{79D73885-0801-45a9-917F-C90FE1CE3DFC}", "name": "Kh-25ML (AS-10 Karen) - 300kg, ASM, Semi-Act Laser", "weight": 360}
-    Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = {"clsid": "{X-25ML}", "name": "Kh-25ML (AS-10 Karen) - 300kg, ASM, Semi-Act Laser", "weight": 360}
-    Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = {"clsid": "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}", "name": "Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr", "weight": 370}
-    Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = {"clsid": "{752AF1D2-EBCC-4bd7-A1E7-2357F5601C70}", "name": "Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr", "weight": 370}
-    Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = {"clsid": "{X-25MPU}", "name": "Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr", "weight": 370}
+    Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = {"clsid": "{X-25ML}", "name": "Kh-25ML (AS-10 Karen) - 300kg, ASM, Semi-Act Laser", "weight": 360}
+    Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = {"clsid": "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}", "name": "Kh-25ML (AS-10 Karen) - 300kg, ASM, Semi-Act Laser", "weight": 360}
+    Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = {"clsid": "{79D73885-0801-45a9-917F-C90FE1CE3DFC}", "name": "Kh-25ML (AS-10 Karen) - 300kg, ASM, Semi-Act Laser", "weight": 360}
+    Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = {"clsid": "{X-25MPU}", "name": "Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr", "weight": 370}
+    Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = {"clsid": "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}", "name": "Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr", "weight": 370}
+    Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = {"clsid": "{752AF1D2-EBCC-4bd7-A1E7-2357F5601C70}", "name": "Kh-25MPU (Updated AS-12 Kegler) - 320kg, ARM, IN & Pas Rdr", "weight": 370}
     Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = {"clsid": "{Kh-25MP}", "name": "Kh-25MP (AS-12 Kegler) - 320kg, ARM, Pas Rdr", "weight": 355}
     Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = {"clsid": "{292960BB-6518-41AC-BADA-210D65D5073C}", "name": "Kh-25MR (AS-10 Karen) - 300kg, ASM, 10km, RC Guided", "weight": 360}
     Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided = {"clsid": "{X-25MR}", "name": "Kh-25MR (AS-10 Karen) - 300kg, ASM, RC Guided", "weight": 360}
     Kh_28__AS_9_Kyle____720kg__ARM__Pas_Rdr = {"clsid": "{Kh-28}", "name": "Kh-28 (AS-9 Kyle) - 720kg, ARM, Pas Rdr", "weight": 715}
-    Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = {"clsid": "{3468C652-E830-4E73-AFA9-B5F260AB7C3D}", "name": "Kh-29L (AS-14 Kedge) - 657kg, ASM, Semi-Act Laser", "weight": 846}
-    Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = {"clsid": "{D4A8D9B9-5C45-42e7-BBD2-0E54F8308432}", "name": "Kh-29L (AS-14 Kedge) - 657kg, ASM, Semi-Act Laser", "weight": 846}
-    Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = {"clsid": "{X-29L}", "name": "Kh-29L (AS-14 Kedge) - 657kg, ASM, Semi-Act Laser", "weight": 660}
-    Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = {"clsid": "{B4FC81C9-B861-4E87-BBDC-A1158E648EBF}", "name": "Kh-29T (AS-14 Kedge) - 670kg, ASM, TV Guided", "weight": 876}
-    Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = {"clsid": "{601C99F7-9AF3-4ed7-A565-F8B8EC0D7AAC}", "name": "Kh-29T (AS-14 Kedge) - 670kg, ASM, TV Guided", "weight": 876}
-    Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = {"clsid": "{X-29T}", "name": "Kh-29T (AS-14 Kedge) - 670kg, ASM, TV Guided", "weight": 690}
+    Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = {"clsid": "{X-29L}", "name": "Kh-29L (AS-14 Kedge) - 657kg, ASM, Semi-Act Laser", "weight": 660}
+    Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = {"clsid": "{3468C652-E830-4E73-AFA9-B5F260AB7C3D}", "name": "Kh-29L (AS-14 Kedge) - 657kg, ASM, Semi-Act Laser", "weight": 846}
+    Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = {"clsid": "{D4A8D9B9-5C45-42e7-BBD2-0E54F8308432}", "name": "Kh-29L (AS-14 Kedge) - 657kg, ASM, Semi-Act Laser", "weight": 846}
+    Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = {"clsid": "{X-29T}", "name": "Kh-29T (AS-14 Kedge) - 670kg, ASM, TV Guided", "weight": 690}
+    Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = {"clsid": "{B4FC81C9-B861-4E87-BBDC-A1158E648EBF}", "name": "Kh-29T (AS-14 Kedge) - 670kg, ASM, TV Guided", "weight": 876}
+    Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = {"clsid": "{601C99F7-9AF3-4ed7-A565-F8B8EC0D7AAC}", "name": "Kh-29T (AS-14 Kedge) - 670kg, ASM, TV Guided", "weight": 876}
     Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = {"clsid": "{4D13E282-DF46-4B23-864A-A9423DFDE504}", "name": "Kh-31A (AS-17 Krypton) - 610kg, AShM, IN & Act Rdr", "weight": 796}
     Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = {"clsid": "{4D13E282-DF46-4B23-864A-A9423DFDE50A}", "name": "Kh-31A (AS-17 Krypton) - 610kg, AShM, IN & Act Rdr", "weight": 796}
     Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = {"clsid": "{X-31A}", "name": "Kh-31A (AS-17 Krypton) - 610kg, AShM, IN & Act Rdr", "weight": 610}
@@ -660,7 +692,8 @@ class Weapons:
     LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = {"clsid": "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", "name": "LAU-10 pod - 4 x 127mm ZUNI, UnGd Rkts Mk71, HE/FRAG", "weight": 288.9}
     LAU_10___4_ZUNI_MK_71 = {"clsid": "{BRU42_LAU10}", "name": "LAU-10 - 4 ZUNI MK 71", "weight": 568}
     LAU_10___4_ZUNI_MK_71_ = {"clsid": "{BRU3242_LAU10}", "name": "LAU-10 - 4 ZUNI MK 71", "weight": 625.38}
-    LAU_115C_with_AIM_7E_2_Sparrow_Semi_Active_Radar = {"clsid": "{LAU-115 - AIM-7E}", "name": "LAU-115C with AIM-7E-2 Sparrow Semi-Active Radar", "weight": 284.4}
+    LAU_115C_with_AIM_7E_2_Sparrow_Semi_Active_Radar = {"clsid": "{LAU-115 - AIM-7E-2}", "name": "LAU-115C with AIM-7E-2 Sparrow Semi-Active Radar", "weight": 284.4}
+    LAU_115C_with_AIM_7E_Sparrow_Semi_Active_Radar = {"clsid": "{LAU-115 - AIM-7E}", "name": "LAU-115C with AIM-7E Sparrow Semi-Active Radar", "weight": 284.4}
     LAU_115C_with_AIM_7F_Sparrow_Semi_Active_Radar = {"clsid": "{LAU-115 - AIM-7F}", "name": "LAU-115C with AIM-7F Sparrow Semi-Active Radar", "weight": 285.4}
     LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar = {"clsid": "{LAU-115 - AIM-7H}", "name": "LAU-115C with AIM-7MH Sparrow Semi-Active Radar", "weight": 285.4}
     LAU_115C_with_AIM_7M_Sparrow_Semi_Active_Radar = {"clsid": "{LAU-115 - AIM-7M}", "name": "LAU-115C with AIM-7M Sparrow Semi-Active Radar", "weight": 285.5}
@@ -704,7 +737,8 @@ class Weapons:
     LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = {"clsid": "{444BA8AE-82A7-4345-842E-76154EFCCA46}", "name": "LAU-117 with AGM-65D - Maverick D (IIR ASM)", "weight": 277}
     LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = {"clsid": "{F16A4DE0-116C-4A71-97F0-2CF85B0313EC}", "name": "LAU-117 with AGM-65E - Maverick E (Laser ASM - Lg Whd)", "weight": 345}
     LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = {"clsid": "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}", "name": "LAU-117 with AGM-65K - Maverick K (CCD Imp ASM)", "weight": 357}
-    LAU_118A___AGM_45B_Shrike_ARM__Imp_ = {"clsid": "{3E6B632D-65EB-44D2-9501-1C2D04515405}", "name": "LAU-118A - AGM-45B Shrike ARM (Imp)", "weight": 222.4}
+    LAU_118A___AGM_45A_Shrike_ARM = {"clsid": "{LAU118_AGM_45A}", "name": "LAU-118A - AGM-45A Shrike ARM", "weight": 222.4}
+    LAU_118A___AGM_45B_Shrike_ARM = {"clsid": "{3E6B632D-65EB-44D2-9501-1C2D04515405}", "name": "LAU-118A - AGM-45B Shrike ARM", "weight": 222.4}
     LAU_127_AIM_9L = {"clsid": "LAU-127_AIM-9L", "name": "LAU-127 AIM-9L Sidewinder IR AAM", "weight": 131.03}
     LAU_127_AIM_9M = {"clsid": "LAU-127_AIM-9M", "name": "LAU-127 AIM-9M Sidewinder IR AAM", "weight": 131.03}
     LAU_127_AIM_9X = {"clsid": "LAU-127_AIM-9X", "name": "LAU-127 AIM-9X Sidewinder IR AAM", "weight": 129.76}
@@ -755,7 +789,8 @@ class Weapons:
     LAU_7_with_2_x_AIM_9P5_Sidewinder_IR_AAM = {"clsid": "{F4-2-AIM9P5}", "name": "LAU-7 with 2 x AIM-9P5 Sidewinder IR AAM", "weight": 191.4}
     LAU_7_with_2_x_AIM_9P_Sidewinder_IR_AAM = {"clsid": "{773675AB-7C29-422f-AFD8-32844A7B7F17}", "name": "LAU-7 with 2 x AIM-9P Sidewinder IR AAM", "weight": 179.68}
     LAU_7_with_AIM_9B_Sidewinder_IR_AAM = {"clsid": "{GAR-8}", "name": "LAU-7 with AIM-9B Sidewinder IR AAM", "weight": 115.39}
-    LAU_7_with_AIM_9J_Sidewinder_IR_AAM = {"clsid": "{AIM-9J-ON-ADAPTER}", "name": "LAU-7 with AIM-9J Sidewinder IR AAM", "weight": 115.84}
+    LAU_7_with_AIM_9E_Sidewinder_IR_AAM = {"clsid": "{AIM-9E-ON-ADAPTER}", "name": "LAU-7 with AIM-9E Sidewinder IR AAM", "weight": 117.43}
+    LAU_7_with_AIM_9J_Sidewinder_IR_AAM = {"clsid": "{AIM-9J-ON-ADAPTER}", "name": "LAU-7 with AIM-9J Sidewinder IR AAM", "weight": 117.93}
     LAU_7_with_AIM_9L_Sidewinder_IR_AAM = {"clsid": "{AIM-9L-ON-ADAPTER}", "name": "LAU-7 with AIM-9L Sidewinder IR AAM", "weight": 126.55328}
     LAU_7_with_AIM_9M_Sidewinder_IR_AAM = {"clsid": "{AIM-9M-ON-ADAPTER}", "name": "LAU-7 with AIM-9M Sidewinder IR AAM", "weight": 126.73}
     LAU_7_with_AIM_9P3_Sidewinder_IR_AAM = {"clsid": "{AIM-9P3-ON-ADAPTER}", "name": "LAU-7 with AIM-9P3 Sidewinder IR AAM", "weight": 121.7}
@@ -1081,6 +1116,12 @@ class Weapons:
     SAMP_400___400_kg_GP_Bomb_LD = {"clsid": "{SAMP400LD}", "name": "SAMP-400 - 400 kg GP Bomb LD", "weight": 360}
     SAMP_400___400_kg_GP_Chute_Retarded_Bomb_HD = {"clsid": "{SAMP400HD}", "name": "SAMP-400 - 400 kg GP Chute Retarded Bomb HD", "weight": 395}
     Sand_Filter = {"clsid": "{FAS}", "name": "Sand Filter", "weight": 15}
+    Sargent_Fletcher_Fuel_Tank_370_gallons = {"clsid": "{F4_SARGENT_TANK_370_GAL}", "name": "Sargent Fletcher Fuel Tank 370 gallons", "weight": 1260.06}
+    Sargent_Fletcher_Fuel_Tank_370_gallons_ = {"clsid": "{F4_SARGENT_TANK_370_GAL_R}", "name": "Sargent Fletcher Fuel Tank 370 gallons", "weight": 1260.06}
+    Sargent_Fletcher_Fuel_Tank_370_gallons__empty_ = {"clsid": "{F4_SARGENT_TANK_370_GAL_EMPTY}", "name": "Sargent Fletcher Fuel Tank 370 gallons (empty)", "weight": 149.7}
+    Sargent_Fletcher_Fuel_Tank_370_gallons__empty__ = {"clsid": "{F4_SARGENT_TANK_370_GAL_R_EMPTY}", "name": "Sargent Fletcher Fuel Tank 370 gallons (empty)", "weight": 149.7}
+    Sargent_Fletcher_Fuel_Tank_600_gallons = {"clsid": "{F4_SARGENT_TANK_600_GAL}", "name": "Sargent Fletcher Fuel Tank 600 gallons", "weight": 1929.7}
+    Sargent_Fletcher_Fuel_Tank_600_gallons__empty_ = {"clsid": "{F4_SARGENT_TANK_600_GAL_EMPTY}", "name": "Sargent Fletcher Fuel Tank 600 gallons (empty)", "weight": 149.7}
     SC_250_Type_1_L2___250kg_GP_Bomb_LD = {"clsid": "{SC_250_T1_L2}", "name": "SC 250 Type 1 L2 - 250kg GP Bomb LD", "weight": 250}
     SC_250_Type_3_J___250kg_GP_Bomb_LD = {"clsid": "{Schloss500XIIC1_SC_250_T3_J}", "name": "SC 250 Type 3 J - 250kg GP Bomb LD", "weight": 270}
     SC_500_L2___500kg_GP_Bomb_LD = {"clsid": "{SC_500_L2}", "name": "SC 500 L2 - 500kg GP Bomb LD", "weight": 500}
@@ -1123,6 +1164,7 @@ class Weapons:
     SPRD_99_takeoff_rocket = {"clsid": "{SPRD}", "name": "SPRD-99 takeoff rocket", "weight": 500}
     SPS_141_100__21____jamming_and_countermeasures_pod = {"clsid": "{SPS-141-100}", "name": "SPS-141-100 (21) - jamming and countermeasures pod", "weight": 150}
     SPS_141___ECM_Jamming_Pod = {"clsid": "{F75187EF-1D9E-4DA9-84B4-1A1A14A3973A}", "name": "SPS-141 - ECM Jamming Pod", "weight": 150}
+    SUU_23 = {"clsid": "{SUU_23_POD}", "name": "SUU-23", "weight": 612.35}
     SUU_25_x_8_LUU_2___Target_Marker_Flares = {"clsid": "{CAE48299-A294-4bad-8EE6-89EFC5DCDF00}", "name": "SUU-25 x 8 LUU-2 - Target Marker Flares", "weight": 130}
     SUU_25___8_LUU_2 = {"clsid": "{BRU42_SUU25}", "name": "SUU-25 * 8 LUU-2", "weight": 258}
     SUU_25___8_LUU_2_ = {"clsid": "{BRU3242_SUU25}", "name": "SUU-25 * 8 LUU-2", "weight": 315.38}
@@ -1226,6 +1268,23 @@ class Weapons:
     _150_US_gal__Fuel_Tank = {"clsid": "{US_150GAL_FUEL_TANK}", "name": "150 US gal. Fuel Tank", "weight": 458.8}
     _1xMistral_ATAM = {"clsid": "{SA342_Mistral_L1}", "name": "1xMistral ATAM", "weight": 99.2}
     _1xMistral_ATAM_ = {"clsid": "{SA342_Mistral_R1}", "name": "1xMistral ATAM", "weight": 99.2}
+    _1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_ = {"clsid": "{HB_F4E_CBU-1A_MER_1x_Left}", "name": "1x CBU-1A/A x 27x19 (513) BLU-4B Bomblets, HE (MER)", "weight": 429.26201328}
+    _1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__ = {"clsid": "{HB_F4E_CBU-1A_MER_1x_Right}", "name": "1x CBU-1A/A x 27x19 (513) BLU-4B Bomblets, HE (MER)", "weight": 429.26201328}
+    _1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER___ = {"clsid": "{HB_F4E_CBU-1A_MER_1x}", "name": "1x CBU-1A/A x 27x19 (513) BLU-4B Bomblets, HE (MER)", "weight": 429.26201328}
+    _1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_ = {"clsid": "{HB_F4E_CBU-2BA_MER_1x_Left}", "name": "1x CBU-2B/A x 22x19 (418) BLU-3B Bomblets, HE (MER)", "weight": 482.69515088}
+    _1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__ = {"clsid": "{HB_F4E_CBU-2BA_MER_1x_Right}", "name": "1x CBU-2B/A x 22x19 (418) BLU-3B Bomblets, HE (MER)", "weight": 482.69515088}
+    _1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER___ = {"clsid": "{HB_F4E_CBU-2BA_MER_1x}", "name": "1x CBU-2B/A x 22x19 (418) BLU-3B Bomblets, HE (MER)", "weight": 482.69515088}
+    _1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_ = {"clsid": "{HB_F4E_CBU-2A_MER_1x_Left}", "name": "1x CBU-2/A x 19x19 (361) BLU-3 Bomblets, HE (MER)", "weight": 437.96644376}
+    _1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__ = {"clsid": "{HB_F4E_CBU-2A_MER_1x_Right}", "name": "1x CBU-2/A x 19x19 (361) BLU-3 Bomblets, HE (MER)", "weight": 437.96644376}
+    _1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER___ = {"clsid": "{HB_F4E_CBU-2A_MER_1x}", "name": "1x CBU-2/A x 19x19 (361) BLU-3 Bomblets, HE (MER)", "weight": 437.96644376}
+    _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = {"clsid": "{HB_F4E_LAU-3_WP156_1x}", "name": "1x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 375.4}
+    _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = {"clsid": "{HB_F4E_LAU-3_MK1_1x}", "name": "1x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 347.8}
+    _1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = {"clsid": "{HB_F4E_LAU-3_MK5_1x}", "name": "1x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 348.7}
+    _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = {"clsid": "{HB_F4E_LAU-68_WP156_1x}", "name": "1x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 248.2}
+    _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = {"clsid": "{HB_F4E_LAU-68_MK1_1x}", "name": "1x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 238}
+    _1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = {"clsid": "{HB_F4E_LAU-68_MK5_1x}", "name": "1x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 238.3}
+    _1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple = {"clsid": "{HB_F4E_MK-83_MER_1x_Left_Ripple}", "name": "1x Mk-83 - 1000lb GP Bomb LD (MER) Ripple", "weight": 553.8}
+    _1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple_ = {"clsid": "{HB_F4E_MK-83_MER_1x_Right_Ripple}", "name": "1x Mk-83 - 1000lb GP Bomb LD (MER) Ripple", "weight": 553.8}
     _1_x_HOT_3___ATGM__SACLOS__HEAT = {"clsid": "{HOT3_R1}", "name": "1 x HOT-3 - ATGM, SACLOS, HEAT", "weight": 54.5}
     _1_x_HOT_3___ATGM__SACLOS__HEAT_ = {"clsid": "{HOT3_L1}", "name": "1 x HOT-3 - ATGM, SACLOS, HEAT", "weight": 54.5}
     _1_x_HOT_3___ATGM__SACLOS__HEAT__ = {"clsid": "{HOT3_L1_M}", "name": "1 x HOT-3 - ATGM, SACLOS, HEAT", "weight": 54.5}
@@ -1250,6 +1309,54 @@ class Weapons:
     _2xMistral_ATAM = {"clsid": "{SA342_Mistral_R2}", "name": "2xMistral ATAM", "weight": 117.9}
     _2xMistral_ATAM_ = {"clsid": "{SA342_Mistral_L2}", "name": "2xMistral ATAM", "weight": 117.9}
     _2x_80kg_LYSB_71_Illumination_Bomb = {"clsid": "{LYSBOMB}", "name": "2x 80kg LYSB-71 Illumination Bomb", "weight": 220}
+    _2x_AGM_65A___Maverick_A__TV_Guided___LAU_88_ = {"clsid": "{HB_F4EAGM-65A_LAU88_2x_Right}", "name": "2x AGM-65A - Maverick A (TV Guided) (LAU-88)", "weight": 632}
+    _2x_AGM_65A___Maverick_A__TV_Guided___LAU_88__ = {"clsid": "{HB_F4EAGM-65A_LAU88_2x_Left}", "name": "2x AGM-65A - Maverick A (TV Guided) (LAU-88)", "weight": 632}
+    _2x_AGM_65B___Maverick_B__TV_Guided___LAU_88_ = {"clsid": "{HB_F4EAGM-65B_LAU88_2x_Right}", "name": "2x AGM-65B - Maverick B (TV Guided) (LAU-88)", "weight": 632}
+    _2x_AGM_65B___Maverick_B__TV_Guided___LAU_88__ = {"clsid": "{HB_F4EAGM-65B_LAU88_2x_Left}", "name": "2x AGM-65B - Maverick B (TV Guided) (LAU-88)", "weight": 632}
+    _2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_ = {"clsid": "{HB_F4EAGM-65D_LAU88_2x_Right}", "name": "2x AGM-65D - Maverick D (IIR ASM) (LAU-88)", "weight": 632}
+    _2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__ = {"clsid": "{HB_F4EAGM-65D_LAU88_2x_Left}", "name": "2x AGM-65D - Maverick D (IIR ASM) (LAU-88)", "weight": 632}
+    _2x_AIM_9L = {"clsid": "{LAU-7_AIM-9L_Left}", "name": "2x AIM-9L", "weight": 100.5}
+    _2x_AIM_9L_ = {"clsid": "{LAU-7_AIM-9L_Right}", "name": "2x AIM-9L", "weight": 100.5}
+    _2x_AIM_9M = {"clsid": "{LAU-7_AIM-9M_Left}", "name": "2x AIM-9M", "weight": 101.64}
+    _2x_AIM_9M_ = {"clsid": "{LAU-7_AIM-9M_Right}", "name": "2x AIM-9M", "weight": 101.64}
+    _2x_BDU_33___25lb_Practice_Bomb_LD__TER_ = {"clsid": "{HB_F4E_BDU-33_2x}", "name": "2x BDU-33 - 25lb Practice Bomb LD (TER)", "weight": 150.6}
+    _2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_ = {"clsid": "{HB_F4E_BDU_45LGB_2x}", "name": "2x BDU-45 LG - 500lb Practice Laser Guided Bomb (TER)", "weight": 682}
+    _2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = {"clsid": "{HB_F4E_BDU-50HD_2x}", "name": "2x BDU-50HD - 500lb Practice Bomb HD (TER)", "weight": 610}
+    _2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = {"clsid": "{HB_F4E_BDU-50LD_2x}", "name": "2x BDU-50LD - 500lb Practice Bomb LD (TER)", "weight": 610}
+    _2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_ = {"clsid": "{HB_F4E_CBU-1A_MER_2x_Left}", "name": "2x CBU-1A/A x 27x19 (513) BLU-4B Bomblets, HE (MER)", "weight": 758.72402656}
+    _2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__ = {"clsid": "{HB_F4E_CBU-1A_MER_2x_Right}", "name": "2x CBU-1A/A x 27x19 (513) BLU-4B Bomblets, HE (MER)", "weight": 758.72402656}
+    _2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_ = {"clsid": "{HB_F4E_CBU-2BA_MER_2x_Left}", "name": "2x CBU-2B/A x 22x19 (418) BLU-3B Bomblets, HE (MER)", "weight": 865.59030176}
+    _2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__ = {"clsid": "{HB_F4E_CBU-2BA_MER_2x_Right}", "name": "2x CBU-2B/A x 22x19 (418) BLU-3B Bomblets, HE (MER)", "weight": 865.59030176}
+    _2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_ = {"clsid": "{HB_F4E_CBU-2A_MER_2x_Left}", "name": "2x CBU-2/A x 19x19 (361) BLU-3 Bomblets, HE (MER)", "weight": 776.13288752}
+    _2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__ = {"clsid": "{HB_F4E_CBU-2A_MER_2x_Right}", "name": "2x CBU-2/A x 19x19 (361) BLU-3 Bomblets, HE (MER)", "weight": 776.13288752}
+    _2x_CBU_52B___220_x_HE_Frag_bomblets__TER_ = {"clsid": "{HB_F4E_CBU-52B_2x}", "name": "2x CBU-52B - 220 x HE/Frag bomblets (TER)", "weight": 840}
+    _2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_ = {"clsid": "{HB_F4E_CBU-87_2x}", "name": "2x CBU-87 - 202 x CEM Cluster Bomb (TER)", "weight": 988}
+    _2x_GBU_12___500lb_Laser_Guided_Bomb__TER_ = {"clsid": "{HB_F4E_GBU-12_2x}", "name": "2x GBU-12 - 500lb Laser Guided Bomb (TER)", "weight": 682}
+    _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = {"clsid": "{HB_F4E_LAU-3_WP156_2x_Right}", "name": "2x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 622.8}
+    _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__ = {"clsid": "{HB_F4E_LAU-3_WP156_2x_Left}", "name": "2x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 622.8}
+    _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = {"clsid": "{HB_F4E_LAU-3_MK1_2x_Right}", "name": "2x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 567.6}
+    _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__ = {"clsid": "{HB_F4E_LAU-3_MK1_2x_Left}", "name": "2x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 567.6}
+    _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = {"clsid": "{HB_F4E_LAU-3_MK5_2x_Right}", "name": "2x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 569.4}
+    _2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__ = {"clsid": "{HB_F4E_LAU-3_MK5_2x_Left}", "name": "2x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 569.4}
+    _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = {"clsid": "{HB_F4E_LAU-68_WP156_2x_Right}", "name": "2x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 368.4}
+    _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__ = {"clsid": "{HB_F4E_LAU-68_WP156_2x_Left}", "name": "2x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 368.4}
+    _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = {"clsid": "{HB_F4E_LAU-68_MK1_2x_Right}", "name": "2x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 348}
+    _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__ = {"clsid": "{HB_F4E_LAU-68_MK1_2x_Left}", "name": "2x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 348}
+    _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = {"clsid": "{HB_F4E_LAU-68_MK5_2x_Right}", "name": "2x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 348.6}
+    _2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__ = {"clsid": "{HB_F4E_LAU-68_MK5_2x_Left}", "name": "2x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 348.6}
+    _2x_M117___750lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_M117_2x_Left}", "name": "2x M117 - 750lb GP Bomb LD (TER)", "weight": 808}
+    _2x_M117___750lb_GP_Bomb_LD__TER__ = {"clsid": "{HB_F4E_M117_2x_Right}", "name": "2x M117 - 750lb GP Bomb LD (TER)", "weight": 808}
+    _2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = {"clsid": "{HB_F4E_ROCKEYE_2x}", "name": "2x Mk-20 Rockeye - 490lbs CBU, 247 x HEAT Bomblets (TER)", "weight": 572}
+    _2x_Mk_81___250lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-81_2x}", "name": "2x Mk-81 - 250lb GP Bomb LD (TER)", "weight": 364}
+    _2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = {"clsid": "{HB_F4E_MK-82AIR_2x}", "name": "2x Mk-82 AIR Ballute - 500lb GP Bomb HD (TER)", "weight": 612}
+    _2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = {"clsid": "{HB_F4E_MK-82_Snakeye_2x}", "name": "2x Mk-82 Snakeye - 500lb GP Bomb HD (TER)", "weight": 627}
+    _2x_Mk_82___500lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-82_2x}", "name": "2x Mk-82 - 500lb GP Bomb LD (TER)", "weight": 584}
+    _2x_Mk_83___1000lb_GP_Bomb_LD__MER_ = {"clsid": "{HB_F4E_MK-83_MER_2x}", "name": "2x Mk-83 - 1000lb GP Bomb LD (MER)", "weight": 1007.8}
+    _2x_Mk_83___1000lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-83_2x_Left}", "name": "2x Mk-83 - 1000lb GP Bomb LD (TER)", "weight": 1036}
+    _2x_Mk_83___1000lb_GP_Bomb_LD__TER__ = {"clsid": "{HB_F4E_MK-83_2x_Right}", "name": "2x Mk-83 - 1000lb GP Bomb LD (TER)", "weight": 1036}
+    _2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER_ = {"clsid": "{HB_F4E_SUU-25_MER_2x_Left}", "name": "2x SUU-25 x 8 LUU-2 - Target Marker Flares (MER)", "weight": 553.4}
+    _2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER__ = {"clsid": "{HB_F4E_SUU-25_MER_2x_Right}", "name": "2x SUU-25 x 8 LUU-2 - Target Marker Flares (MER)", "weight": 553.4}
+    _2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER___ = {"clsid": "{HB_F4E_SUU-25_MER_2x}", "name": "2x SUU-25 x 8 LUU-2 - Target Marker Flares (MER)", "weight": 553.4}
     _2_BDU_45 = {"clsid": "{BRU42_2*BDU45 RS}", "name": "2 BDU-45", "weight": 592}
     _2_BDU_45B = {"clsid": "{BRU42_2*BDU45B RS}", "name": "2 BDU-45B", "weight": 592}
     _2_BDU_45B_ = {"clsid": "{BRU3242_2*BDU45B RS}", "name": "2 BDU-45B", "weight": 649.38}
@@ -1338,8 +1445,8 @@ class Weapons:
     _2_SUU_25___8_LUU_2_ = {"clsid": "{BRU3242_2*SUU25 L}", "name": "2 SUU-25 * 8 LUU-2", "weight": 445.38}
     _2_SUU_25___8_LUU_2__ = {"clsid": "{BRU42_2*SUU25 R}", "name": "2 SUU-25 * 8 LUU-2", "weight": 388}
     _2_SUU_25___8_LUU_2___ = {"clsid": "{BRU3242_2*SUU25 R}", "name": "2 SUU-25 * 8 LUU-2", "weight": 445.38}
-    _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = {"clsid": "{B919B0F4-7C25-455E-9A02-CEA51DB895E3}", "name": "2 x 9M114 Shturm-V (AT-6 Spiral) - ATGM, SACLOS, HEAT", "weight": 103.8}
-    _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT_ = {"clsid": "{2x9M114_with_adapter}", "name": "2 x 9M114 Shturm-V (AT-6 Spiral) - ATGM, SACLOS, HEAT", "weight": 108.8}
+    _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = {"clsid": "{B919B0F4-7C25-455E-9A02-CEA51DB895E3}", "name": "2 x 9M114 Kokon (AT-6 Spiral) - ATGM, SACLOS, HEAT", "weight": 103.8}
+    _2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT_ = {"clsid": "{2x9M114_with_adapter}", "name": "2 x 9M114 Kokon (AT-6 Spiral) - ATGM, SACLOS, HEAT", "weight": 108.8}
     _2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE = {"clsid": "{2x9M120F_Ataka_V}", "name": "2 x 9M120F Ataka (AT-9 Spiral-2) - AGM, SACLOS, HE", "weight": 118}
     _2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE_ = {"clsid": "{2x9M120F_Ataka_V_with_adapter}", "name": "2 x 9M120F Ataka (AT-9 Spiral-2) - AGM, SACLOS, HE", "weight": 123}
     _2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT = {"clsid": "{2x9M120_Ataka_V}", "name": "2 x 9M120 Ataka (AT-9 Spiral-2) - ATGM, SACLOS, Tandem HEAT", "weight": 118}
@@ -1390,6 +1497,43 @@ class Weapons:
     _30_6_M2___18_x_BAT_120_ABL___34kg_HE_Frag_Chute_Retarded_Bomb_HD = {"clsid": "{30_6_M2_18xBAT120}", "name": "30-6-M2 - 18 x BAT-120 ABL - 34kg HE/Frag Chute Retarded Bomb HD", "weight": 762}
     _33_x_FAB_250___250kg_GP_Bombs_LD = {"clsid": "{BDAD04AA-4D4A-4E51-B958-180A89F963CF}", "name": "33 x FAB-250 - 250kg GP Bombs LD", "weight": 8250}
     _33_x_FAB_500_M_62___500kg_GP_Bombs_LD = {"clsid": "{AD5E5863-08FC-4283-B92C-162E2B2BD3FF}", "name": "33 x FAB-500 M-62 - 500kg GP Bombs LD", "weight": 16500}
+    _3x_AGM_65A___Maverick_A__TV_Guided___LAU_88_ = {"clsid": "{HB_F4EAGM-65A_LAU88_3x_Right}", "name": "3x AGM-65A - Maverick A (TV Guided) (LAU-88)", "weight": 842.5}
+    _3x_AGM_65A___Maverick_A__TV_Guided___LAU_88__ = {"clsid": "{HB_F4EAGM-65A_LAU88_3x_Left}", "name": "3x AGM-65A - Maverick A (TV Guided) (LAU-88)", "weight": 842.5}
+    _3x_AGM_65B___Maverick_B__TV_Guided___LAU_88_ = {"clsid": "{HB_F4EAGM-65B_LAU88_3x_Right}", "name": "3x AGM-65B - Maverick B (TV Guided) (LAU-88)", "weight": 842.5}
+    _3x_AGM_65B___Maverick_B__TV_Guided___LAU_88__ = {"clsid": "{HB_F4EAGM-65B_LAU88_3x_Left}", "name": "3x AGM-65B - Maverick B (TV Guided) (LAU-88)", "weight": 842.5}
+    _3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_ = {"clsid": "{HB_F4EAGM-65D_LAU88_3x_Right}", "name": "3x AGM-65D - Maverick D (IIR ASM) (LAU-88)", "weight": 842.5}
+    _3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__ = {"clsid": "{HB_F4EAGM-65D_LAU88_3x_Left}", "name": "3x AGM-65D - Maverick D (IIR ASM) (LAU-88)", "weight": 842.5}
+    _3x_BDU_33___25lb_Practice_Bomb_LD__TER_ = {"clsid": "{HB_F4E_BDU-33_3x}", "name": "3x BDU-33 - 25lb Practice Bomb LD (TER)", "weight": 161.9}
+    _3x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = {"clsid": "{HB_F4E_BDU-50HD_3x}", "name": "3x BDU-50HD - 500lb Practice Bomb HD (TER)", "weight": 851}
+    _3x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = {"clsid": "{HB_F4E_BDU-50LD_3x}", "name": "3x BDU-50LD - 500lb Practice Bomb LD (TER)", "weight": 851}
+    _3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_ = {"clsid": "{HB_F4E_BLU-107B_3x}", "name": "3x BLU-107/B Durandal - 219kg Concrete Piercing Chute Retarded Bomb w/Booster (TER)", "weight": 785}
+    _3x_CBU_52B___220_x_HE_Frag_bomblets__MER_ = {"clsid": "{HB_F4E_CBU-52B_MER_3x_Left}", "name": "3x CBU-52B - 220 x HE/Frag bomblets (MER)", "weight": 1167.8}
+    _3x_CBU_52B___220_x_HE_Frag_bomblets__MER__ = {"clsid": "{HB_F4E_CBU-52B_MER_3x_Right}", "name": "3x CBU-52B - 220 x HE/Frag bomblets (MER)", "weight": 1167.8}
+    _3x_CBU_87___202_x_CEM_Cluster_Bomb__MER_ = {"clsid": "{HB_F4E_CBU-87_MER_3x_Left}", "name": "3x CBU-87 - 202 x CEM Cluster Bomb (MER)", "weight": 1389.8}
+    _3x_CBU_87___202_x_CEM_Cluster_Bomb__MER__ = {"clsid": "{HB_F4E_CBU-87_MER_3x_Right}", "name": "3x CBU-87 - 202 x CEM Cluster Bomb (MER)", "weight": 1389.8}
+    _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_ = {"clsid": "{HB_F4E_LAU-3_WP156_MER_3x}", "name": "3x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (MER)", "weight": 842}
+    _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = {"clsid": "{HB_F4E_LAU-3_WP156_3x}", "name": "3x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 870.2}
+    _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_ = {"clsid": "{HB_F4E_LAU-3_MK1_MER_3x}", "name": "3x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk1, HE (MER)", "weight": 759.2}
+    _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = {"clsid": "{HB_F4E_LAU-3_MK1_3x}", "name": "3x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 787.4}
+    _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_ = {"clsid": "{HB_F4E_LAU-3_MK5_MER_3x}", "name": "3x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (MER)", "weight": 761.9}
+    _3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = {"clsid": "{HB_F4E_LAU-3_MK5_3x}", "name": "3x LAU-3 pod - 19 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 790.1}
+    _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_ = {"clsid": "{HB_F4E_LAU-68_WP156_MER_3x}", "name": "3x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (MER)", "weight": 460.4}
+    _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_ = {"clsid": "{HB_F4E_LAU-68_WP156_3x}", "name": "3x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts M156, Wht Phos (TER)", "weight": 488.6}
+    _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_ = {"clsid": "{HB_F4E_LAU-68_MK1_MER_3x}", "name": "3x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk1, HE (MER)", "weight": 429.8}
+    _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_ = {"clsid": "{HB_F4E_LAU-68_MK1_3x}", "name": "3x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk1, HE (TER)", "weight": 458}
+    _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_ = {"clsid": "{HB_F4E_LAU-68_MK5_MER_3x}", "name": "3x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (MER)", "weight": 430.7}
+    _3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_ = {"clsid": "{HB_F4E_LAU-68_MK5_3x}", "name": "3x LAU-68 pod - 7 x 2.75\" FFAR, UnGd Rkts Mk5, HEAT (TER)", "weight": 458.9}
+    _3x_M117___750lb_GP_Bomb_LD__MER_ = {"clsid": "{HB_F4E_M117_MER_3x_Left}", "name": "3x M117 - 750lb GP Bomb LD (MER)", "weight": 1119.8}
+    _3x_M117___750lb_GP_Bomb_LD__MER__ = {"clsid": "{HB_F4E_M117_MER_3x_Right}", "name": "3x M117 - 750lb GP Bomb LD (MER)", "weight": 1119.8}
+    _3x_M117___750lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_M117_3x}", "name": "3x M117 - 750lb GP Bomb LD (TER)", "weight": 1148}
+    _3x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = {"clsid": "{HB_F4E_ROCKEYE_3x}", "name": "3x Mk-20 Rockeye - 490lbs CBU, 247 x HEAT Bomblets (TER)", "weight": 794}
+    _3x_Mk_81___250lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-81_3x}", "name": "3x Mk-81 - 250lb GP Bomb LD (TER)", "weight": 482}
+    _3x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = {"clsid": "{HB_F4E_MK-82AIR_3x}", "name": "3x Mk-82 AIR Ballute - 500lb GP Bomb HD (TER)", "weight": 854}
+    _3x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = {"clsid": "{HB_F4E_MK-82_Snakeye_3x}", "name": "3x Mk-82 Snakeye - 500lb GP Bomb HD (TER)", "weight": 876.5}
+    _3x_Mk_82___500lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-82_3x}", "name": "3x Mk-82 - 500lb GP Bomb LD (TER)", "weight": 812}
+    _3x_Mk_83___1000lb_GP_Bomb_LD__MER_ = {"clsid": "{HB_F4E_MK-83_MER_3x}", "name": "3x Mk-83 - 1000lb GP Bomb LD (MER)", "weight": 1461.8}
+    _3x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple = {"clsid": "{HB_F4E_MK-83_MER_3x_Ripple}", "name": "3x Mk-83 - 1000lb GP Bomb LD (MER) Ripple", "weight": 1461.8}
+    _3x_Mk_83___1000lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-83_3x}", "name": "3x Mk-83 - 1000lb GP Bomb LD (TER)", "weight": 1490}
     _3_BDU_33 = {"clsid": "{BRU42_3*BDU33}", "name": "3 BDU-33", "weight": 161}
     _3_BDU_33_ = {"clsid": "{BRU3242_3*BDU33}", "name": "3 BDU-33", "weight": 218.38}
     _3_BDU_33__ = {"clsid": "{BRU42_3*BDU33_N}", "name": "3 BDU-33", "weight": 161}
@@ -1408,6 +1552,8 @@ class Weapons:
     _3_x_4_5_inch_M8_UnGd_Rocket = {"clsid": "{3xM8_ROCKETS_IN_TUBES}", "name": "3 x 4.5 inch M8 UnGd Rocket", "weight": 71.72}
     _3_x_FAB_1500_M_54___1500kg_GP_Bombs_LD = {"clsid": "{639DB5DD-CB7E-4E42-AC75-2112BC397B97}", "name": "3 x FAB-1500 M-54 - 1500kg GP Bombs LD", "weight": 4500}
     _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = {"clsid": "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}", "name": "3 x LAU-61 pods - 57 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 876.45}
+    _4x_CBU_52B___220_x_HE_Frag_bomblets__MER_ = {"clsid": "{HB_F4E_CBU-52B_MER_6x}", "name": "4x CBU-52B - 220 x HE/Frag bomblets (MER)", "weight": 1523.8}
+    _4x_CBU_87___202_x_CEM_Cluster_Bomb__MER_ = {"clsid": "{HB_F4E_CBU-87_MER_4x}", "name": "4x CBU-87 - 202 x CEM Cluster Bomb (MER)", "weight": 1819.8}
     _4x_SB_M_71_120kg_GP_Bomb_High_drag = {"clsid": "{M71BOMBD}", "name": "4x SB M/71 120kg GP Bomb High-drag", "weight": 609}
     _4x_SB_M_71_120kg_GP_Bomb_Low_drag = {"clsid": "{M71BOMB}", "name": "4x SB M/71 120kg GP Bomb Low-drag", "weight": 609}
     _4_x_AGM_154C___JSOW_Unitary_BROACH = {"clsid": "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}", "name": "4 x AGM-154C - JSOW Unitary BROACH", "weight": 2700.9}
@@ -1430,10 +1576,20 @@ class Weapons:
     _500_lb_MC_Short_tail_ = {"clsid": "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}", "name": "500 lb MC Short tail", "weight": 231.6}
     _500_lb_S_A_P_ = {"clsid": "{British_SAP_500LB_Bomb_Mk5}", "name": "500 lb S.A.P.", "weight": 222.26}
     _50_gal__Drop_Tank = {"clsid": "{MOSQUITO_50GAL_SLIPPER_TANK}", "name": "50 gal. Drop Tank", "weight": 187.7}
+    _5x_M117___750lb_GP_Bomb_LD__MER_ = {"clsid": "{HB_F4E_M117_MER_5x}", "name": "5x M117 - 750lb GP Bomb LD (MER)", "weight": 1799.8}
     _5_x_HVAR__UnGd_Rkt = {"clsid": "{P47_5_HVARS_ON_LEFT_WING_RAILS}", "name": "5 x HVAR, UnGd Rkt", "weight": 330}
     _5_x_HVAR__UnGd_Rkt_ = {"clsid": "{P47_5_HVARS_ON_RIGHT_WING_RAILS}", "name": "5 x HVAR, UnGd Rkt", "weight": 330}
     _5_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = {"clsid": "{MER-5E_Mk82SNAKEYEx5}", "name": "5 x Mk-82 Snakeye - 500lb GP Bomb HD", "weight": 1250.7}
     _5_x_Mk_82___500lb_GP_Bombs_LD = {"clsid": "{MER-5E_MK82x5}", "name": "5 x Mk-82 - 500lb GP Bombs LD", "weight": 1295.7}
+    _6x_BDU_33___25lb_Practice_Bomb_LD__MER_ = {"clsid": "{HB_F4E_BDU-33_6x}", "name": "6x BDU-33 - 25lb Practice Bomb LD (MER)", "weight": 167.6}
+    _6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_ = {"clsid": "{HB_F4E_BDU-50HD_6x}", "name": "6x BDU-50HD - 500lb Practice Bomb HD (MER)", "weight": 1545.8}
+    _6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_ = {"clsid": "{HB_F4E_BDU-50LD_6x}", "name": "6x BDU-50LD - 500lb Practice Bomb LD (MER)", "weight": 1545.8}
+    _6x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__MER_ = {"clsid": "{HB_F4E_BLU-107B_6x}", "name": "6x BLU-107/B Durandal - 219kg Concrete Piercing Chute Retarded Bomb w/Booster (MER)", "weight": 1413.8}
+    _6x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__MER_ = {"clsid": "{HB_F4E_ROCKEYE_6x}", "name": "6x Mk-20 Rockeye - 490lbs CBU, 247 x HEAT Bomblets (MER)", "weight": 1431.8}
+    _6x_Mk_81___250lb_GP_Bomb_LD__MER_ = {"clsid": "{HB_F4E_MK-81_6x}", "name": "6x Mk-81 - 250lb GP Bomb LD (MER)", "weight": 807.8}
+    _6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_ = {"clsid": "{HB_F4E_MK-82AIR_6x}", "name": "6x Mk-82 AIR Ballute - 500lb GP Bomb HD (MER)", "weight": 1551.8}
+    _6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_ = {"clsid": "{HB_F4E_MK-82_Snakeye_6x}", "name": "6x Mk-82 Snakeye - 500lb GP Bomb HD (MER)", "weight": 1596.8}
+    _6x_Mk_82___500lb_GP_Bomb_LD__MER_ = {"clsid": "{HB_F4E_MK-82_6x}", "name": "6x Mk-82 - 500lb GP Bomb LD (MER)", "weight": 1467.8}
     _6_x_AGM_86D_on_MER = {"clsid": "{45447F82-01B5-4029-A572-9AAD28AF0275}", "name": "6 x AGM-86D on MER", "weight": 10716.7}
     _6_x_BetAB_500___500kg_Concrete_Piercing_Bombs_LD = {"clsid": "{2B7BDB38-4F45-43F9-BE02-E7B3141F3D24}", "name": "6 x BetAB-500 - 500kg Concrete Piercing Bombs LD", "weight": 2868}
     _6_x_FAB_1500_M_54___1500kg_GP_Bombs_LD = {"clsid": "{D9179118-E42F-47DE-A483-A6C2EA7B4F38}", "name": "6 x FAB-1500 M-54 - 1500kg GP Bombs LD", "weight": 9000}
@@ -1443,13 +1599,45 @@ class Weapons:
     _6_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = {"clsid": "{E79759F7-C622-4AA4-B1EF-37639A34D924}", "name": "6 x Mk-20 Rockeye - 490lbs CBUs, 247 x HEAT Bomblets", "weight": 1332}
     _6_x_Mk_82___500lb_GP_Bombs_LD = {"clsid": "{027563C9-D87E-4A85-B317-597B510E3F03}", "name": "6 x Mk-82 - 500lb GP Bombs LD", "weight": 1446}
     _75_US_gal__Fuel_Tank = {"clsid": "{DT75GAL}", "name": "75 US gal. Fuel Tank", "weight": 227.048087675}
-    _8_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = {"clsid": "{57232979-8B0F-4db7-8D9A-55197E06B0F5}", "name": "8 x 9M114 Shturm-V (AT-6 Spiral) - ATGM, SACLOS, HEAT", "weight": 457.2}
+    _8_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT = {"clsid": "{57232979-8B0F-4db7-8D9A-55197E06B0F5}", "name": "8 x 9M114 Kokon (AT-6 Spiral) - ATGM, SACLOS, HEAT", "weight": 457.2}
     _8_x_AGM_84A_Harpoon_ASM = {"clsid": "{46ACDCF8-5451-4E26-BDDB-E78D5830E93C}", "name": "8 x AGM-84A Harpoon ASM", "weight": 5292}
     _8_x_AGM_86C = {"clsid": "{8_x_AGM_86C}", "name": "8 x AGM-86C", "weight": 17040.6}
     _8_x_AGM_86D = {"clsid": "{8DCAF3A3-7FCF-41B8-BB88-58DEDA878EDE}", "name": "8 x AGM-86D", "weight": 13040.6}
     _8_x_Kh_65__AS_15B_Kent____1250kg__ASM__IN__MCC = {"clsid": "{CD9417DF-455F-4176-A5A2-8C58D61AA00B}", "name": "8 x Kh-65 (AS-15B Kent) - 1250kg, ASM, IN & MCC", "weight": 10000}
     _9S846_Strelets___2_x_9M39_Igla = {"clsid": "{9S846_2xIGLA}", "name": "9S846 Strelets - 2 x 9M39 Igla", "weight": 78.4}
     _NiteHawk_FLIR = {"clsid": "_NiteHawk_FLIR", "name": "AN/AAS-38 \"Nite hawk\" FLIR, Laser designator & Laser spot tracker pod", "weight": 200}
+    _Special_Weapons_Adapter__2x_BDU_33___25lb_Practice_Bomb_LD__TER_ = {"clsid": "{HB_F4E_BDU-33_2x_SWA}", "name": "(Special Weapons Adapter) 2x BDU-33 - 25lb Practice Bomb LD (TER)", "weight": 150.6}
+    _Special_Weapons_Adapter__2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_ = {"clsid": "{HB_F4E_BDU_45LGB_2x_SWA}", "name": "(Special Weapons Adapter) 2x BDU-45 LG - 500lb Practice Laser Guided Bomb (TER)", "weight": 682}
+    _Special_Weapons_Adapter__2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_ = {"clsid": "{HB_F4E_BDU-50HD_2x_SWA}", "name": "(Special Weapons Adapter) 2x BDU-50HD - 500lb Practice Bomb HD (TER)", "weight": 610}
+    _Special_Weapons_Adapter__2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_ = {"clsid": "{HB_F4E_BDU-50LD_2x_SWA}", "name": "(Special Weapons Adapter) 2x BDU-50LD - 500lb Practice Bomb LD (TER)", "weight": 610}
+    _Special_Weapons_Adapter__2x_CBU_52B___220_x_HE_Frag_bomblets__TER_ = {"clsid": "{HB_F4E_CBU-52B_2x_SWA}", "name": "(Special Weapons Adapter) 2x CBU-52B - 220 x HE/Frag bomblets (TER)", "weight": 840}
+    _Special_Weapons_Adapter__2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_ = {"clsid": "{HB_F4E_CBU-87_2x_SWA}", "name": "(Special Weapons Adapter) 2x CBU-87 - 202 x CEM Cluster Bomb (TER)", "weight": 988}
+    _Special_Weapons_Adapter__2x_GBU_12___500lb_Laser_Guided_Bomb__TER_ = {"clsid": "{HB_F4E_GBU-12_2x_SWA}", "name": "(Special Weapons Adapter) 2x GBU-12 - 500lb Laser Guided Bomb (TER)", "weight": 682}
+    _Special_Weapons_Adapter__2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_ = {"clsid": "{HB_F4E_ROCKEYE_2x_SWA}", "name": "(Special Weapons Adapter) 2x Mk-20 Rockeye - 490lbs CBU, 247 x HEAT Bomblets (TER)", "weight": 572}
+    _Special_Weapons_Adapter__2x_Mk_81___250lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-81_2x_SWA}", "name": "(Special Weapons Adapter) 2x Mk-81 - 250lb GP Bomb LD (TER)", "weight": 364}
+    _Special_Weapons_Adapter__2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_ = {"clsid": "{HB_F4E_MK-82AIR_2x_SWA}", "name": "(Special Weapons Adapter) 2x Mk-82 AIR Ballute - 500lb GP Bomb HD (TER)", "weight": 612}
+    _Special_Weapons_Adapter__2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_ = {"clsid": "{HB_F4E_MK-82_Snakeye_2x_SWA}", "name": "(Special Weapons Adapter) 2x Mk-82 Snakeye - 500lb GP Bomb HD (TER)", "weight": 627}
+    _Special_Weapons_Adapter__2x_Mk_82___500lb_GP_Bomb_LD__TER_ = {"clsid": "{HB_F4E_MK-82_2x_SWA}", "name": "(Special Weapons Adapter) 2x Mk-82 - 500lb GP Bomb LD (TER)", "weight": 584}
+    _Special_Weapons_Adapter__3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_ = {"clsid": "{HB_F4E_BLU-107B_3x_SWA}", "name": "(Special Weapons Adapter) 3x BLU-107/B Durandal - 219kg Concrete Piercing Chute Retarded Bomb w/Booster (TER)", "weight": 785}
+    _Special_Weapons_Adapter__AGM_12A_Bullpup_MCLOS_ASM__LAU_34_ = {"clsid": "{AGM_12A_SWA}", "name": "(Special Weapons Adapter) AGM-12A Bullpup MCLOS ASM (LAU-34)", "weight": 296}
+    _Special_Weapons_Adapter__AGM_12B_Bullpup_MCLOS_ASM__LAU_34_ = {"clsid": "{AGM_12B_SWA}", "name": "(Special Weapons Adapter) AGM-12B Bullpup MCLOS ASM (LAU-34)", "weight": 302}
+    _Special_Weapons_Adapter__AGM_12C_Bullpup_MCLOS_ASM = {"clsid": "{AGM_12C_SWA}", "name": "(Special Weapons Adapter) AGM-12C Bullpup MCLOS ASM", "weight": 811.5}
+    _Special_Weapons_Adapter__AGM_45A_Shrike_ARM__LAU_34_ = {"clsid": "{LAU_34_AGM_45A_SWA}", "name": "(Special Weapons Adapter) AGM-45A Shrike ARM (LAU-34)", "weight": 219}
+    _Special_Weapons_Adapter__AGM_65A___Maverick_A__TV_Guided___LAU_117__Special_Weapons_Adapter__ = {"clsid": "{HB_F4E_AGM-65A_LAU117_SWA}", "name": "(Special Weapons Adapter) AGM-65A - Maverick A (TV Guided) (LAU-117)(Special Weapons Adapter) ", "weight": 269.5}
+    _Special_Weapons_Adapter__AGM_65B___Maverick_B__TV_Guided___LAU_117__Special_Weapons_Adapter__ = {"clsid": "{HB_F4E_AGM-65B_LAU117_SWA}", "name": "(Special Weapons Adapter) AGM-65B - Maverick B (TV Guided) (LAU-117)(Special Weapons Adapter) ", "weight": 269.5}
+    _Special_Weapons_Adapter__AGM_65D___Maverick_D__IIR_ASM___LAU_117__Special_Weapons_Adapter__ = {"clsid": "{HB_F4E_AGM-65D_LAU117_SWA}", "name": "(Special Weapons Adapter) AGM-65D - Maverick D (IIR ASM) (LAU-117)(Special Weapons Adapter) ", "weight": 269.5}
+    _Special_Weapons_Adapter__BDU_33___25lb_Practice_Bomb_LD = {"clsid": "{HB_BDU-33_SWA}", "name": "(Special Weapons Adapter) BDU-33 - 25lb Practice Bomb LD", "weight": 11.3}
+    _Special_Weapons_Adapter__BDU_45_LG___500lb_Practice_Laser_Guided_Bomb = {"clsid": "{HB_BDU_45LGB_SWA}", "name": "(Special Weapons Adapter) BDU-45 LG - 500lb Practice Laser Guided Bomb", "weight": 277}
+    _Special_Weapons_Adapter__BDU_50HD___500lb_Practice_Bomb_HD = {"clsid": "{HB_BDU-50HD_SWA}", "name": "(Special Weapons Adapter) BDU-50HD - 500lb Practice Bomb HD", "weight": 241}
+    _Special_Weapons_Adapter__BDU_50LD___500lb_Practice_Bomb_LD = {"clsid": "{HB_BDU-50LD_SWA}", "name": "(Special Weapons Adapter) BDU-50LD - 500lb Practice Bomb LD", "weight": 241}
+    _Special_Weapons_Adapter__CBU_52B___220_x_HE_Frag_bomblets = {"clsid": "{HB_CBU-52B_SWA}", "name": "(Special Weapons Adapter) CBU-52B - 220 x HE/Frag bomblets", "weight": 356}
+    _Special_Weapons_Adapter__CBU_87___202_x_CEM_Cluster_Bomb = {"clsid": "{HB_CBU-87_SWA}", "name": "(Special Weapons Adapter) CBU-87 - 202 x CEM Cluster Bomb", "weight": 430}
+    _Special_Weapons_Adapter__GBU_12___500lb_Laser_Guided_Bomb = {"clsid": "{HB_GBU-12_SWA}", "name": "(Special Weapons Adapter) GBU-12 - 500lb Laser Guided Bomb", "weight": 277}
+    _Special_Weapons_Adapter__Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = {"clsid": "{HB_ROCKEYE_SWA}", "name": "(Special Weapons Adapter) Mk-20 Rockeye - 490lbs CBU, 247 x HEAT Bomblets", "weight": 222}
+    _Special_Weapons_Adapter__Mk_81___250lb_GP_Bomb_LD = {"clsid": "{HB_MK-81_SWA}", "name": "(Special Weapons Adapter) Mk-81 - 250lb GP Bomb LD", "weight": 118}
+    _Special_Weapons_Adapter__Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = {"clsid": "{HB_MK-82AIR_SWA}", "name": "(Special Weapons Adapter) Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 242}
+    _Special_Weapons_Adapter__Mk_82_Snakeye___500lb_GP_Bomb_HD = {"clsid": "{HB_MK-82_Snakeye_SWA}", "name": "(Special Weapons Adapter) Mk-82 Snakeye - 500lb GP Bomb HD", "weight": 249.5}
+    _Special_Weapons_Adapter__Mk_82___500lb_GP_Bomb_LD = {"clsid": "{HB_MK-82_SWA}", "name": "(Special Weapons Adapter) Mk-82 - 500lb GP Bomb LD", "weight": 228}
 
 weapon_ids = {
     "{AB_250_2_SD_2}": Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions,
@@ -1469,19 +1657,28 @@ weapon_ids = {
     "{AGM_122_SIDEARM}": Weapons.AGM_122_Sidearm,
     "{LAU_7_AGM_122_SIDEARM}": Weapons.AGM_122_Sidearm_,
     "{AGM_122}": Weapons.AGM_122_Sidearm___light_ARM,
-    "{AGM_12A}": Weapons.AGM_12A_Bullpup___MCLOS_missile,
-    "{AGM_12B}": Weapons.AGM_12B_Bullpup___MCLOS_missile,
+    "{AGM_12A}": Weapons.AGM_12A_Bullpup_MCLOS_ASM__LAU_34_,
+    "{AGM_12B}": Weapons.AGM_12B_Bullpup_MCLOS_ASM__LAU_34_,
+    "{AGM_12C}": Weapons.AGM_12C_Bullpup_MCLOS_ASM,
+    "{HB_F4E_AGM_12C}": Weapons.AGM_12C_Bullpup___MCLOS_missile,
     "{AGM_130C_9}": Weapons.AGM_130C_9___3000lb_TV__EO__Guided_Missile,
     "{AGM-154A}": Weapons.AGM_154A___JSOW_CEB__CBU_type_,
     "{AGM-154B}": Weapons.AGM_154B___JSOW_Anti_Armour,
     "{9BCC2A2B-5708-4860-B1F1-053A18442067}": Weapons.AGM_154C___JSOW_Unitary_BROACH,
     "{AGM_45A}": Weapons.AGM_45A_Shrike_ARM,
-    "{3E6B632D-65EB-44D2-9501-1C2D04515404}": Weapons.AGM_45B_Shrike_ARM__Imp_,
+    "{LAU_34_AGM_45A}": Weapons.AGM_45A_Shrike_ARM__LAU_34_,
+    "{AGM_45B}": Weapons.AGM_45B_Shrike_ARM,
     "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}": Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_,
     "{AGM_62_I}": Weapons.AGM_62_Walleye_I___Guided_Weapon_Mk_1__TV_Guided_,
+    "{HB_F4E_AGM-65A_LAU117}": Weapons.AGM_65A___Maverick_A__TV_Guided___LAU_117_,
+    "{HB_F4E_AGM-65B_LAU117}": Weapons.AGM_65B___Maverick_B__TV_Guided___LAU_117_,
     "{444BA8AE-82A7-4345-842E-76154EFCCA47}": Weapons.AGM_65D___Maverick_D__IIR_ASM_,
+    "{HB_F4E_AGM-65D_LAU117}": Weapons.AGM_65D___Maverick_D__IIR_ASM___LAU_117_,
     "{F16A4DE0-116C-4A71-97F0-2CF85B0313EF}": Weapons.AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_,
+    "{HB_F4E_AGM-65G_LAU117}": Weapons.AGM_65G___Maverick_G__IIR_ASM___Lg_Whd___LAU_117_,
     "{69DC8AE7-8F77-427B-B8AA-B19D3F478B65}": Weapons.AGM_65K___Maverick_K__CCD_Imp_ASM_,
+    "{AGM_78A}": Weapons.AGM_78A_Standard_ARM,
+    "{AGM_78B}": Weapons.AGM_78B_Standard_ARM,
     "{8B7CADF9-4954-46B3-8CFB-93F2F5B90B03}": Weapons.AGM_84A_Harpoon_ASM,
     "{AGM_84D}": Weapons.AGM_84D_Harpoon_AShM,
     "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}": Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_,
@@ -1508,23 +1705,30 @@ weapon_ids = {
     "{SHOULDER AIM_54C_Mk60 R}": Weapons.AIM_54C_Mk60__,
     "{SHOULDER AIM-7E}": Weapons.AIM_7E,
     "{BELLY AIM-7E}": Weapons.AIM_7E_,
-    "{AIM-7E}": Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar,
-    "{SHOULDER AIM-7F}": Weapons.AIM_7F,
-    "{BELLY AIM-7F}": Weapons.AIM_7F_,
+    "{AIM-7E-2}": Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar,
+    "{HB_F4E_AIM-7E-2}": Weapons.AIM_7E_2_Sparrow_Semi_Active_Radar_,
+    "{AIM-7E}": Weapons.AIM_7E_Sparrow_Semi_Active_Radar,
+    "{HB_F4E_AIM-7E}": Weapons.AIM_7E_Sparrow_Semi_Active_Radar_,
+    "{HB_F4E_AIM-7F}": Weapons.AIM_7F,
+    "{SHOULDER AIM-7F}": Weapons.AIM_7F_,
     "{AIM-7F}": Weapons.AIM_7F_Sparrow_Semi_Active_Radar,
-    "{SHOULDER AIM-7M}": Weapons.AIM_7M,
+    "{BELLY AIM-7F}": Weapons.AIM_7F__,
+    "{HB_F4E_AIM-7M}": Weapons.AIM_7M,
     "{SHOULDER AIM-7MH}": Weapons.AIM_7MH,
     "{BELLY AIM-7MH}": Weapons.AIM_7MH_,
     "{AIM-7H}": Weapons.AIM_7MH_Sparrow_Semi_Active_Radar,
-    "{BELLY AIM-7M}": Weapons.AIM_7M_,
+    "{SHOULDER AIM-7M}": Weapons.AIM_7M_,
     "{8D399DDA-FF81-4F14-904D-099B34FE7918}": Weapons.AIM_7M_Sparrow_Semi_Active_Radar,
+    "{BELLY AIM-7M}": Weapons.AIM_7M__,
     "{SHOULDER AIM-7P}": Weapons.AIM_7P,
     "{BELLY AIM-7P}": Weapons.AIM_7P_,
     "{AIM-7P}": Weapons.AIM_7P_Sparrow_Semi_Active_Radar,
     "{AIM-9B}": Weapons.AIM_9B_Sidewinder_IR_AAM,
+    "{AIM-9E}": Weapons.AIM_9E_Sidewinder_IR_AAM,
     "{AIM-9JULI}": Weapons.AIM_9JULI_Sidewinder_IR_AAM,
     "{AIM-9J}": Weapons.AIM_9J_Sidewinder_IR_AAM,
     "{AIM-9L}": Weapons.AIM_9L_Sidewinder_IR_AAM,
+    "{AIM-9M}": Weapons.AIM_9M,
     "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}": Weapons.AIM_9M_Sidewinder_IR_AAM,
     "{AIM-9P3}": Weapons.AIM_9P3_Sidewinder_IR_AAM,
     "{AIM-9P5}": Weapons.AIM_9P5_Sidewinder_IR_AAM,
@@ -1534,7 +1738,13 @@ weapon_ids = {
     "{AKAN}": Weapons.AKAN_M_55_Gunpod__150_rnds_MINGR55_HE,
     "{AKAN_NO_TRC}": Weapons.AKAN_M_55_Gunpod__150_rnds_MINGR55_HE__no_Tracer_,
     "{E6747967-B1F0-4C77-977B-AB2E6EB0C102}": Weapons.ALARM,
+    "{HB_ALE_40_0_120}": Weapons.ALE_40_Dispensers__120_Chaff_,
+    "{HB_ALE_40_15_90}": Weapons.ALE_40_Dispensers__15_Flares__90_Chaff_,
+    "{HB_ALE_40_30_0}": Weapons.ALE_40_Dispensers__30_Flares_,
+    "{HB_ALE_40_30_60}": Weapons.ALE_40_Dispensers__30_Flares__60_Chaff_,
+    "{HB_ALE_40_0_0}": Weapons.ALE_40_Dispensers__Empty_,
     "{6D21ECEA-F85B-4E8D-9D51-31DC9B8AA4EF}": Weapons.ALQ_131___ECM_Pod,
+    "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}": Weapons.ALQ_131___ECM_Pod_Rack,
     "{F14-ALQ167}": Weapons.ALQ_167__non_functional_,
     "ALQ_184": Weapons.ALQ_184,
     "ALQ_184_Long": Weapons.ALQ_184_Long,
@@ -1552,6 +1762,10 @@ weapon_ids = {
     "{AIS_ASQ_T50}": Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod,
     "{LAU-138 wtip - TCTS L}": Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod_,
     "{LAU-138 wtip - TCTS R}": Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod__,
+    "{HB_PAVE_SPIKE_FAST_TRACK}": Weapons.AN_AVQ_23_Pave_Spike__Fast_Smart_Track____Targeting_Pod,
+    "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}": Weapons.AN_AVQ_23_Pave_Spike__Fast_Smart_Track____Targeting_Pod_Rack,
+    "{HB_PAVE_SPIKE}": Weapons.AN_AVQ_23_Pave_Spike___Targeting_Pod,
+    "{HB_PAVE_SPIKE_ON_ADAPTER_IN_AERO7}": Weapons.AN_AVQ_23_Pave_Spike___Targeting_Pod_Rack,
     "{AN_AXQ_14}": Weapons.AN_AXQ_14_Data_Link_Pod,
     "{AN_M30A1}": Weapons.AN_M30A1___100lb_GP_Bomb_LD,
     "{MB339_ANM3_L}": Weapons.AN_M3_Gunpod_Left,
@@ -1982,12 +2196,13 @@ weapon_ids = {
     "{CFT_L_GBU_12_x_4}": Weapons.GBU_12___4,
     "{CFT_R_GBU_12_x_4}": Weapons.GBU_12___4_,
     "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}": Weapons.GBU_12___500lb_Laser_Guided_Bomb,
+    "{GBU-15V1}": Weapons.GBU_15_V1___2000_lb_TV_Guided_Bomb,
     "{GBU_15_V_31B}": Weapons.GBU_15_V_31_B___2000lb_TV__EO__Guided_Bomb,
     "{BRU-32 GBU-16}": Weapons.GBU_16,
     "{0D33DDAE-524F-4A4E-B5B8-621754FE3ADE}": Weapons.GBU_16___1000lb_Laser_Guided_Bomb,
     "{BRU-32 GBU-24}": Weapons.GBU_24,
-    "{GBU-24}": Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb,
-    "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}": Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb,
+    "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}": Weapons.GBU_24A_B_Paveway_III___2000lb_Laser_Guided_Bomb,
+    "{GBU-24}": Weapons.GBU_24B_B_Paveway_III___2000lb_Laser_Guided_Bomb,
     "{CFT_R_GBU_27_x_2}": Weapons.GBU_27___2,
     "{EF0A9419-01D6-473B-99A3-BEBDB923B14D}": Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb,
     "{F06B775B-FC70-44B5-8A9F-5B5E2EB839C7}": Weapons.GBU_28___5000lb_Laser_Guided_Penetrator_Bomb,
@@ -2009,6 +2224,7 @@ weapon_ids = {
     "{CFT_L_GBU_54_x_3}": Weapons.GBU_54B___3,
     "{CFT_R_GBU_54_x_3}": Weapons.GBU_54B___3_,
     "{GBU_54_V_1B}": Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD,
+    "{HB_F4E_GBU_8}": Weapons.GBU_8_HOBOS___2000_lb_TV_Guided_Bomb,
     "{GB-6}": Weapons.GB_6,
     "{GB-6-HE}": Weapons.GB_6_HE,
     "{GB-6-SFW}": Weapons.GB_6_SFW,
@@ -2019,6 +2235,10 @@ weapon_ids = {
     "{GIAT_M621_SAPHEI}": Weapons.GIAT_M621__240x_SAPHEI_,
     "GUV_VOG": Weapons.GUV_VOG,
     "GUV_YakB_GSHP": Weapons.GUV_YakB_GSHP,
+    "{HB_F4E_CBU-1/A}": Weapons.HB_F4E_CBU_1_A_pod___19_x_tubes_of_Bomblets_BLU_3B_x_27__HE,
+    "{HB_F4E_CBU-2B/A}": Weapons.HB_F4E_CBU_2B_A_pod___19_x_tubes_of_Bomblets_BLU_3B_x_22__HE,
+    "{HB_F4E_CBU-2/A}": Weapons.HB_F4E_CBU_2_A_pod___19_x_tubes_of_Bomblets_BLU_3B_x_19__HE,
+    "{F4_HIGH_PERFORMANCE_CENTERLINE_600_GAL}": Weapons.High_Performance_Centerline_Tank_600_gallons,
     "{HSAB-6xAGM-84}": Weapons.HSAB_with_6_x_AGM_84,
     "{696CFFC4-0BDE-42A8-BE4B-0BE3D9DD723C}": Weapons.HSAB_with_6_x_Mk_84___2000lb_GP_Bombs_LD,
     "{4CD2BB0F-5493-44EF-A927-9760350F7BA1}": Weapons.HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
@@ -2044,22 +2264,22 @@ weapon_ids = {
     "{KD_63B}": Weapons.KD_63B,
     "{12429ECF-03F0-4DF6-BCBD-5D38B6343DE1}": Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr,
     "{9F390892-E6F9-42C9-B84E-1136A881DCB2}": Weapons.Kh_23L_Grom__AS_7_Kerry____286kg__ASM__Laser_Guided,
-    "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}": Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser,
-    "{79D73885-0801-45a9-917F-C90FE1CE3DFC}": Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_,
-    "{X-25ML}": Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__,
-    "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}": Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr,
-    "{752AF1D2-EBCC-4bd7-A1E7-2357F5601C70}": Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_,
-    "{X-25MPU}": Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__,
+    "{X-25ML}": Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser,
+    "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}": Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_,
+    "{79D73885-0801-45a9-917F-C90FE1CE3DFC}": Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__,
+    "{X-25MPU}": Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr,
+    "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}": Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_,
+    "{752AF1D2-EBCC-4bd7-A1E7-2357F5601C70}": Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__,
     "{Kh-25MP}": Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr,
     "{292960BB-6518-41AC-BADA-210D65D5073C}": Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided,
     "{X-25MR}": Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided,
     "{Kh-28}": Weapons.Kh_28__AS_9_Kyle____720kg__ARM__Pas_Rdr,
-    "{3468C652-E830-4E73-AFA9-B5F260AB7C3D}": Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser,
-    "{D4A8D9B9-5C45-42e7-BBD2-0E54F8308432}": Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_,
-    "{X-29L}": Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
-    "{B4FC81C9-B861-4E87-BBDC-A1158E648EBF}": Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided,
-    "{601C99F7-9AF3-4ed7-A565-F8B8EC0D7AAC}": Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_,
-    "{X-29T}": Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
+    "{X-29L}": Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser,
+    "{3468C652-E830-4E73-AFA9-B5F260AB7C3D}": Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_,
+    "{D4A8D9B9-5C45-42e7-BBD2-0E54F8308432}": Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+    "{X-29T}": Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided,
+    "{B4FC81C9-B861-4E87-BBDC-A1158E648EBF}": Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_,
+    "{601C99F7-9AF3-4ed7-A565-F8B8EC0D7AAC}": Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
     "{4D13E282-DF46-4B23-864A-A9423DFDE504}": Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr,
     "{4D13E282-DF46-4B23-864A-A9423DFDE50A}": Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_,
     "{X-31A}": Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__,
@@ -2110,7 +2330,8 @@ weapon_ids = {
     "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}": Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
     "{BRU42_LAU10}": Weapons.LAU_10___4_ZUNI_MK_71,
     "{BRU3242_LAU10}": Weapons.LAU_10___4_ZUNI_MK_71_,
-    "{LAU-115 - AIM-7E}": Weapons.LAU_115C_with_AIM_7E_2_Sparrow_Semi_Active_Radar,
+    "{LAU-115 - AIM-7E-2}": Weapons.LAU_115C_with_AIM_7E_2_Sparrow_Semi_Active_Radar,
+    "{LAU-115 - AIM-7E}": Weapons.LAU_115C_with_AIM_7E_Sparrow_Semi_Active_Radar,
     "{LAU-115 - AIM-7F}": Weapons.LAU_115C_with_AIM_7F_Sparrow_Semi_Active_Radar,
     "{LAU-115 - AIM-7H}": Weapons.LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar,
     "{LAU-115 - AIM-7M}": Weapons.LAU_115C_with_AIM_7M_Sparrow_Semi_Active_Radar,
@@ -2154,7 +2375,8 @@ weapon_ids = {
     "{444BA8AE-82A7-4345-842E-76154EFCCA46}": Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_,
     "{F16A4DE0-116C-4A71-97F0-2CF85B0313EC}": Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_,
     "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}": Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
-    "{3E6B632D-65EB-44D2-9501-1C2D04515405}": Weapons.LAU_118A___AGM_45B_Shrike_ARM__Imp_,
+    "{LAU118_AGM_45A}": Weapons.LAU_118A___AGM_45A_Shrike_ARM,
+    "{3E6B632D-65EB-44D2-9501-1C2D04515405}": Weapons.LAU_118A___AGM_45B_Shrike_ARM,
     "LAU-127_AIM-9L": Weapons.LAU_127_AIM_9L,
     "LAU-127_AIM-9M": Weapons.LAU_127_AIM_9M,
     "LAU-127_AIM-9X": Weapons.LAU_127_AIM_9X,
@@ -2205,6 +2427,7 @@ weapon_ids = {
     "{F4-2-AIM9P5}": Weapons.LAU_7_with_2_x_AIM_9P5_Sidewinder_IR_AAM,
     "{773675AB-7C29-422f-AFD8-32844A7B7F17}": Weapons.LAU_7_with_2_x_AIM_9P_Sidewinder_IR_AAM,
     "{GAR-8}": Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+    "{AIM-9E-ON-ADAPTER}": Weapons.LAU_7_with_AIM_9E_Sidewinder_IR_AAM,
     "{AIM-9J-ON-ADAPTER}": Weapons.LAU_7_with_AIM_9J_Sidewinder_IR_AAM,
     "{AIM-9L-ON-ADAPTER}": Weapons.LAU_7_with_AIM_9L_Sidewinder_IR_AAM,
     "{AIM-9M-ON-ADAPTER}": Weapons.LAU_7_with_AIM_9M_Sidewinder_IR_AAM,
@@ -2531,6 +2754,12 @@ weapon_ids = {
     "{SAMP400LD}": Weapons.SAMP_400___400_kg_GP_Bomb_LD,
     "{SAMP400HD}": Weapons.SAMP_400___400_kg_GP_Chute_Retarded_Bomb_HD,
     "{FAS}": Weapons.Sand_Filter,
+    "{F4_SARGENT_TANK_370_GAL}": Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons,
+    "{F4_SARGENT_TANK_370_GAL_R}": Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons_,
+    "{F4_SARGENT_TANK_370_GAL_EMPTY}": Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons__empty_,
+    "{F4_SARGENT_TANK_370_GAL_R_EMPTY}": Weapons.Sargent_Fletcher_Fuel_Tank_370_gallons__empty__,
+    "{F4_SARGENT_TANK_600_GAL}": Weapons.Sargent_Fletcher_Fuel_Tank_600_gallons,
+    "{F4_SARGENT_TANK_600_GAL_EMPTY}": Weapons.Sargent_Fletcher_Fuel_Tank_600_gallons__empty_,
     "{SC_250_T1_L2}": Weapons.SC_250_Type_1_L2___250kg_GP_Bomb_LD,
     "{Schloss500XIIC1_SC_250_T3_J}": Weapons.SC_250_Type_3_J___250kg_GP_Bomb_LD,
     "{SC_500_L2}": Weapons.SC_500_L2___500kg_GP_Bomb_LD,
@@ -2573,6 +2802,7 @@ weapon_ids = {
     "{SPRD}": Weapons.SPRD_99_takeoff_rocket,
     "{SPS-141-100}": Weapons.SPS_141_100__21____jamming_and_countermeasures_pod,
     "{F75187EF-1D9E-4DA9-84B4-1A1A14A3973A}": Weapons.SPS_141___ECM_Jamming_Pod,
+    "{SUU_23_POD}": Weapons.SUU_23,
     "{CAE48299-A294-4bad-8EE6-89EFC5DCDF00}": Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares,
     "{BRU42_SUU25}": Weapons.SUU_25___8_LUU_2,
     "{BRU3242_SUU25}": Weapons.SUU_25___8_LUU_2_,
@@ -2676,6 +2906,23 @@ weapon_ids = {
     "{US_150GAL_FUEL_TANK}": Weapons._150_US_gal__Fuel_Tank,
     "{SA342_Mistral_L1}": Weapons._1xMistral_ATAM,
     "{SA342_Mistral_R1}": Weapons._1xMistral_ATAM_,
+    "{HB_F4E_CBU-1A_MER_1x_Left}": Weapons._1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_,
+    "{HB_F4E_CBU-1A_MER_1x_Right}": Weapons._1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__,
+    "{HB_F4E_CBU-1A_MER_1x}": Weapons._1x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER___,
+    "{HB_F4E_CBU-2BA_MER_1x_Left}": Weapons._1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_,
+    "{HB_F4E_CBU-2BA_MER_1x_Right}": Weapons._1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__,
+    "{HB_F4E_CBU-2BA_MER_1x}": Weapons._1x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER___,
+    "{HB_F4E_CBU-2A_MER_1x_Left}": Weapons._1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_,
+    "{HB_F4E_CBU-2A_MER_1x_Right}": Weapons._1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__,
+    "{HB_F4E_CBU-2A_MER_1x}": Weapons._1x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER___,
+    "{HB_F4E_LAU-3_WP156_1x}": Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_,
+    "{HB_F4E_LAU-3_MK1_1x}": Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_,
+    "{HB_F4E_LAU-3_MK5_1x}": Weapons._1x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_,
+    "{HB_F4E_LAU-68_WP156_1x}": Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_,
+    "{HB_F4E_LAU-68_MK1_1x}": Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_,
+    "{HB_F4E_LAU-68_MK5_1x}": Weapons._1x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_,
+    "{HB_F4E_MK-83_MER_1x_Left_Ripple}": Weapons._1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple,
+    "{HB_F4E_MK-83_MER_1x_Right_Ripple}": Weapons._1x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple_,
     "{HOT3_R1}": Weapons._1_x_HOT_3___ATGM__SACLOS__HEAT,
     "{HOT3_L1}": Weapons._1_x_HOT_3___ATGM__SACLOS__HEAT_,
     "{HOT3_L1_M}": Weapons._1_x_HOT_3___ATGM__SACLOS__HEAT__,
@@ -2700,6 +2947,54 @@ weapon_ids = {
     "{SA342_Mistral_R2}": Weapons._2xMistral_ATAM,
     "{SA342_Mistral_L2}": Weapons._2xMistral_ATAM_,
     "{LYSBOMB}": Weapons._2x_80kg_LYSB_71_Illumination_Bomb,
+    "{HB_F4EAGM-65A_LAU88_2x_Right}": Weapons._2x_AGM_65A___Maverick_A__TV_Guided___LAU_88_,
+    "{HB_F4EAGM-65A_LAU88_2x_Left}": Weapons._2x_AGM_65A___Maverick_A__TV_Guided___LAU_88__,
+    "{HB_F4EAGM-65B_LAU88_2x_Right}": Weapons._2x_AGM_65B___Maverick_B__TV_Guided___LAU_88_,
+    "{HB_F4EAGM-65B_LAU88_2x_Left}": Weapons._2x_AGM_65B___Maverick_B__TV_Guided___LAU_88__,
+    "{HB_F4EAGM-65D_LAU88_2x_Right}": Weapons._2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_,
+    "{HB_F4EAGM-65D_LAU88_2x_Left}": Weapons._2x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__,
+    "{LAU-7_AIM-9L_Left}": Weapons._2x_AIM_9L,
+    "{LAU-7_AIM-9L_Right}": Weapons._2x_AIM_9L_,
+    "{LAU-7_AIM-9M_Left}": Weapons._2x_AIM_9M,
+    "{LAU-7_AIM-9M_Right}": Weapons._2x_AIM_9M_,
+    "{HB_F4E_BDU-33_2x}": Weapons._2x_BDU_33___25lb_Practice_Bomb_LD__TER_,
+    "{HB_F4E_BDU_45LGB_2x}": Weapons._2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_,
+    "{HB_F4E_BDU-50HD_2x}": Weapons._2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_,
+    "{HB_F4E_BDU-50LD_2x}": Weapons._2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_,
+    "{HB_F4E_CBU-1A_MER_2x_Left}": Weapons._2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER_,
+    "{HB_F4E_CBU-1A_MER_2x_Right}": Weapons._2x_CBU_1A_A_x_27x19__513__BLU_4B_Bomblets__HE__MER__,
+    "{HB_F4E_CBU-2BA_MER_2x_Left}": Weapons._2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER_,
+    "{HB_F4E_CBU-2BA_MER_2x_Right}": Weapons._2x_CBU_2B_A_x_22x19__418__BLU_3B_Bomblets__HE__MER__,
+    "{HB_F4E_CBU-2A_MER_2x_Left}": Weapons._2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER_,
+    "{HB_F4E_CBU-2A_MER_2x_Right}": Weapons._2x_CBU_2_A_x_19x19__361__BLU_3_Bomblets__HE__MER__,
+    "{HB_F4E_CBU-52B_2x}": Weapons._2x_CBU_52B___220_x_HE_Frag_bomblets__TER_,
+    "{HB_F4E_CBU-87_2x}": Weapons._2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_,
+    "{HB_F4E_GBU-12_2x}": Weapons._2x_GBU_12___500lb_Laser_Guided_Bomb__TER_,
+    "{HB_F4E_LAU-3_WP156_2x_Right}": Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_,
+    "{HB_F4E_LAU-3_WP156_2x_Left}": Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__,
+    "{HB_F4E_LAU-3_MK1_2x_Right}": Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_,
+    "{HB_F4E_LAU-3_MK1_2x_Left}": Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__,
+    "{HB_F4E_LAU-3_MK5_2x_Right}": Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_,
+    "{HB_F4E_LAU-3_MK5_2x_Left}": Weapons._2x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__,
+    "{HB_F4E_LAU-68_WP156_2x_Right}": Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_,
+    "{HB_F4E_LAU-68_WP156_2x_Left}": Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER__,
+    "{HB_F4E_LAU-68_MK1_2x_Right}": Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_,
+    "{HB_F4E_LAU-68_MK1_2x_Left}": Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER__,
+    "{HB_F4E_LAU-68_MK5_2x_Right}": Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_,
+    "{HB_F4E_LAU-68_MK5_2x_Left}": Weapons._2x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER__,
+    "{HB_F4E_M117_2x_Left}": Weapons._2x_M117___750lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_M117_2x_Right}": Weapons._2x_M117___750lb_GP_Bomb_LD__TER__,
+    "{HB_F4E_ROCKEYE_2x}": Weapons._2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_,
+    "{HB_F4E_MK-81_2x}": Weapons._2x_Mk_81___250lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_MK-82AIR_2x}": Weapons._2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_,
+    "{HB_F4E_MK-82_Snakeye_2x}": Weapons._2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_,
+    "{HB_F4E_MK-82_2x}": Weapons._2x_Mk_82___500lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_MK-83_MER_2x}": Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__MER_,
+    "{HB_F4E_MK-83_2x_Left}": Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_MK-83_2x_Right}": Weapons._2x_Mk_83___1000lb_GP_Bomb_LD__TER__,
+    "{HB_F4E_SUU-25_MER_2x_Left}": Weapons._2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER_,
+    "{HB_F4E_SUU-25_MER_2x_Right}": Weapons._2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER__,
+    "{HB_F4E_SUU-25_MER_2x}": Weapons._2x_SUU_25_x_8_LUU_2___Target_Marker_Flares__MER___,
     "{BRU42_2*BDU45 RS}": Weapons._2_BDU_45,
     "{BRU42_2*BDU45B RS}": Weapons._2_BDU_45B,
     "{BRU3242_2*BDU45B RS}": Weapons._2_BDU_45B_,
@@ -2788,8 +3083,8 @@ weapon_ids = {
     "{BRU3242_2*SUU25 L}": Weapons._2_SUU_25___8_LUU_2_,
     "{BRU42_2*SUU25 R}": Weapons._2_SUU_25___8_LUU_2__,
     "{BRU3242_2*SUU25 R}": Weapons._2_SUU_25___8_LUU_2___,
-    "{B919B0F4-7C25-455E-9A02-CEA51DB895E3}": Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT,
-    "{2x9M114_with_adapter}": Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT_,
+    "{B919B0F4-7C25-455E-9A02-CEA51DB895E3}": Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT,
+    "{2x9M114_with_adapter}": Weapons._2_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT_,
     "{2x9M120F_Ataka_V}": Weapons._2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE,
     "{2x9M120F_Ataka_V_with_adapter}": Weapons._2_x_9M120F_Ataka__AT_9_Spiral_2____AGM__SACLOS__HE_,
     "{2x9M120_Ataka_V}": Weapons._2_x_9M120_Ataka__AT_9_Spiral_2____ATGM__SACLOS__Tandem_HEAT,
@@ -2840,6 +3135,43 @@ weapon_ids = {
     "{30_6_M2_18xBAT120}": Weapons._30_6_M2___18_x_BAT_120_ABL___34kg_HE_Frag_Chute_Retarded_Bomb_HD,
     "{BDAD04AA-4D4A-4E51-B958-180A89F963CF}": Weapons._33_x_FAB_250___250kg_GP_Bombs_LD,
     "{AD5E5863-08FC-4283-B92C-162E2B2BD3FF}": Weapons._33_x_FAB_500_M_62___500kg_GP_Bombs_LD,
+    "{HB_F4EAGM-65A_LAU88_3x_Right}": Weapons._3x_AGM_65A___Maverick_A__TV_Guided___LAU_88_,
+    "{HB_F4EAGM-65A_LAU88_3x_Left}": Weapons._3x_AGM_65A___Maverick_A__TV_Guided___LAU_88__,
+    "{HB_F4EAGM-65B_LAU88_3x_Right}": Weapons._3x_AGM_65B___Maverick_B__TV_Guided___LAU_88_,
+    "{HB_F4EAGM-65B_LAU88_3x_Left}": Weapons._3x_AGM_65B___Maverick_B__TV_Guided___LAU_88__,
+    "{HB_F4EAGM-65D_LAU88_3x_Right}": Weapons._3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88_,
+    "{HB_F4EAGM-65D_LAU88_3x_Left}": Weapons._3x_AGM_65D___Maverick_D__IIR_ASM___LAU_88__,
+    "{HB_F4E_BDU-33_3x}": Weapons._3x_BDU_33___25lb_Practice_Bomb_LD__TER_,
+    "{HB_F4E_BDU-50HD_3x}": Weapons._3x_BDU_50HD___500lb_Practice_Bomb_HD__TER_,
+    "{HB_F4E_BDU-50LD_3x}": Weapons._3x_BDU_50LD___500lb_Practice_Bomb_LD__TER_,
+    "{HB_F4E_BLU-107B_3x}": Weapons._3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_,
+    "{HB_F4E_CBU-52B_MER_3x_Left}": Weapons._3x_CBU_52B___220_x_HE_Frag_bomblets__MER_,
+    "{HB_F4E_CBU-52B_MER_3x_Right}": Weapons._3x_CBU_52B___220_x_HE_Frag_bomblets__MER__,
+    "{HB_F4E_CBU-87_MER_3x_Left}": Weapons._3x_CBU_87___202_x_CEM_Cluster_Bomb__MER_,
+    "{HB_F4E_CBU-87_MER_3x_Right}": Weapons._3x_CBU_87___202_x_CEM_Cluster_Bomb__MER__,
+    "{HB_F4E_LAU-3_WP156_MER_3x}": Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_,
+    "{HB_F4E_LAU-3_WP156_3x}": Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_,
+    "{HB_F4E_LAU-3_MK1_MER_3x}": Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_,
+    "{HB_F4E_LAU-3_MK1_3x}": Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_,
+    "{HB_F4E_LAU-3_MK5_MER_3x}": Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_,
+    "{HB_F4E_LAU-3_MK5_3x}": Weapons._3x_LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_,
+    "{HB_F4E_LAU-68_WP156_MER_3x}": Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__MER_,
+    "{HB_F4E_LAU-68_WP156_3x}": Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos__TER_,
+    "{HB_F4E_LAU-68_MK1_MER_3x}": Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__MER_,
+    "{HB_F4E_LAU-68_MK1_3x}": Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE__TER_,
+    "{HB_F4E_LAU-68_MK5_MER_3x}": Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__MER_,
+    "{HB_F4E_LAU-68_MK5_3x}": Weapons._3x_LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT__TER_,
+    "{HB_F4E_M117_MER_3x_Left}": Weapons._3x_M117___750lb_GP_Bomb_LD__MER_,
+    "{HB_F4E_M117_MER_3x_Right}": Weapons._3x_M117___750lb_GP_Bomb_LD__MER__,
+    "{HB_F4E_M117_3x}": Weapons._3x_M117___750lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_ROCKEYE_3x}": Weapons._3x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_,
+    "{HB_F4E_MK-81_3x}": Weapons._3x_Mk_81___250lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_MK-82AIR_3x}": Weapons._3x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_,
+    "{HB_F4E_MK-82_Snakeye_3x}": Weapons._3x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_,
+    "{HB_F4E_MK-82_3x}": Weapons._3x_Mk_82___500lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_MK-83_MER_3x}": Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__MER_,
+    "{HB_F4E_MK-83_MER_3x_Ripple}": Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__MER__Ripple,
+    "{HB_F4E_MK-83_3x}": Weapons._3x_Mk_83___1000lb_GP_Bomb_LD__TER_,
     "{BRU42_3*BDU33}": Weapons._3_BDU_33,
     "{BRU3242_3*BDU33}": Weapons._3_BDU_33_,
     "{BRU42_3*BDU33_N}": Weapons._3_BDU_33__,
@@ -2858,6 +3190,8 @@ weapon_ids = {
     "{3xM8_ROCKETS_IN_TUBES}": Weapons._3_x_4_5_inch_M8_UnGd_Rocket,
     "{639DB5DD-CB7E-4E42-AC75-2112BC397B97}": Weapons._3_x_FAB_1500_M_54___1500kg_GP_Bombs_LD,
     "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}": Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+    "{HB_F4E_CBU-52B_MER_6x}": Weapons._4x_CBU_52B___220_x_HE_Frag_bomblets__MER_,
+    "{HB_F4E_CBU-87_MER_4x}": Weapons._4x_CBU_87___202_x_CEM_Cluster_Bomb__MER_,
     "{M71BOMBD}": Weapons._4x_SB_M_71_120kg_GP_Bomb_High_drag,
     "{M71BOMB}": Weapons._4x_SB_M_71_120kg_GP_Bomb_Low_drag,
     "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}": Weapons._4_x_AGM_154C___JSOW_Unitary_BROACH,
@@ -2880,10 +3214,20 @@ weapon_ids = {
     "{British_MC_500LB_Bomb_Mk1_Short_on_Handley_Page_Type_B_Cut_Bar}": Weapons._500_lb_MC_Short_tail_,
     "{British_SAP_500LB_Bomb_Mk5}": Weapons._500_lb_S_A_P_,
     "{MOSQUITO_50GAL_SLIPPER_TANK}": Weapons._50_gal__Drop_Tank,
+    "{HB_F4E_M117_MER_5x}": Weapons._5x_M117___750lb_GP_Bomb_LD__MER_,
     "{P47_5_HVARS_ON_LEFT_WING_RAILS}": Weapons._5_x_HVAR__UnGd_Rkt,
     "{P47_5_HVARS_ON_RIGHT_WING_RAILS}": Weapons._5_x_HVAR__UnGd_Rkt_,
     "{MER-5E_Mk82SNAKEYEx5}": Weapons._5_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
     "{MER-5E_MK82x5}": Weapons._5_x_Mk_82___500lb_GP_Bombs_LD,
+    "{HB_F4E_BDU-33_6x}": Weapons._6x_BDU_33___25lb_Practice_Bomb_LD__MER_,
+    "{HB_F4E_BDU-50HD_6x}": Weapons._6x_BDU_50HD___500lb_Practice_Bomb_HD__MER_,
+    "{HB_F4E_BDU-50LD_6x}": Weapons._6x_BDU_50LD___500lb_Practice_Bomb_LD__MER_,
+    "{HB_F4E_BLU-107B_6x}": Weapons._6x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__MER_,
+    "{HB_F4E_ROCKEYE_6x}": Weapons._6x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__MER_,
+    "{HB_F4E_MK-81_6x}": Weapons._6x_Mk_81___250lb_GP_Bomb_LD__MER_,
+    "{HB_F4E_MK-82AIR_6x}": Weapons._6x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__MER_,
+    "{HB_F4E_MK-82_Snakeye_6x}": Weapons._6x_Mk_82_Snakeye___500lb_GP_Bomb_HD__MER_,
+    "{HB_F4E_MK-82_6x}": Weapons._6x_Mk_82___500lb_GP_Bomb_LD__MER_,
     "{45447F82-01B5-4029-A572-9AAD28AF0275}": Weapons._6_x_AGM_86D_on_MER,
     "{2B7BDB38-4F45-43F9-BE02-E7B3141F3D24}": Weapons._6_x_BetAB_500___500kg_Concrete_Piercing_Bombs_LD,
     "{D9179118-E42F-47DE-A483-A6C2EA7B4F38}": Weapons._6_x_FAB_1500_M_54___1500kg_GP_Bombs_LD,
@@ -2893,11 +3237,43 @@ weapon_ids = {
     "{E79759F7-C622-4AA4-B1EF-37639A34D924}": Weapons._6_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets,
     "{027563C9-D87E-4A85-B317-597B510E3F03}": Weapons._6_x_Mk_82___500lb_GP_Bombs_LD,
     "{DT75GAL}": Weapons._75_US_gal__Fuel_Tank,
-    "{57232979-8B0F-4db7-8D9A-55197E06B0F5}": Weapons._8_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT,
+    "{57232979-8B0F-4db7-8D9A-55197E06B0F5}": Weapons._8_x_9M114_Kokon__AT_6_Spiral____ATGM__SACLOS__HEAT,
     "{46ACDCF8-5451-4E26-BDDB-E78D5830E93C}": Weapons._8_x_AGM_84A_Harpoon_ASM,
     "{8_x_AGM_86C}": Weapons._8_x_AGM_86C,
     "{8DCAF3A3-7FCF-41B8-BB88-58DEDA878EDE}": Weapons._8_x_AGM_86D,
     "{CD9417DF-455F-4176-A5A2-8C58D61AA00B}": Weapons._8_x_Kh_65__AS_15B_Kent____1250kg__ASM__IN__MCC,
     "{9S846_2xIGLA}": Weapons._9S846_Strelets___2_x_9M39_Igla,
-    "_NiteHawk_FLIR": Weapons._NiteHawk_FLIR
+    "_NiteHawk_FLIR": Weapons._NiteHawk_FLIR,
+    "{HB_F4E_BDU-33_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_BDU_33___25lb_Practice_Bomb_LD__TER_,
+    "{HB_F4E_BDU_45LGB_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_BDU_45_LG___500lb_Practice_Laser_Guided_Bomb__TER_,
+    "{HB_F4E_BDU-50HD_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_BDU_50HD___500lb_Practice_Bomb_HD__TER_,
+    "{HB_F4E_BDU-50LD_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_BDU_50LD___500lb_Practice_Bomb_LD__TER_,
+    "{HB_F4E_CBU-52B_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_CBU_52B___220_x_HE_Frag_bomblets__TER_,
+    "{HB_F4E_CBU-87_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_CBU_87___202_x_CEM_Cluster_Bomb__TER_,
+    "{HB_F4E_GBU-12_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_GBU_12___500lb_Laser_Guided_Bomb__TER_,
+    "{HB_F4E_ROCKEYE_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets__TER_,
+    "{HB_F4E_MK-81_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_Mk_81___250lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_MK-82AIR_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD__TER_,
+    "{HB_F4E_MK-82_Snakeye_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_Mk_82_Snakeye___500lb_GP_Bomb_HD__TER_,
+    "{HB_F4E_MK-82_2x_SWA}": Weapons._Special_Weapons_Adapter__2x_Mk_82___500lb_GP_Bomb_LD__TER_,
+    "{HB_F4E_BLU-107B_3x_SWA}": Weapons._Special_Weapons_Adapter__3x_BLU_107_B_Durandal___219kg_Concrete_Piercing_Chute_Retarded_Bomb_w_Booster__TER_,
+    "{AGM_12A_SWA}": Weapons._Special_Weapons_Adapter__AGM_12A_Bullpup_MCLOS_ASM__LAU_34_,
+    "{AGM_12B_SWA}": Weapons._Special_Weapons_Adapter__AGM_12B_Bullpup_MCLOS_ASM__LAU_34_,
+    "{AGM_12C_SWA}": Weapons._Special_Weapons_Adapter__AGM_12C_Bullpup_MCLOS_ASM,
+    "{LAU_34_AGM_45A_SWA}": Weapons._Special_Weapons_Adapter__AGM_45A_Shrike_ARM__LAU_34_,
+    "{HB_F4E_AGM-65A_LAU117_SWA}": Weapons._Special_Weapons_Adapter__AGM_65A___Maverick_A__TV_Guided___LAU_117__Special_Weapons_Adapter__,
+    "{HB_F4E_AGM-65B_LAU117_SWA}": Weapons._Special_Weapons_Adapter__AGM_65B___Maverick_B__TV_Guided___LAU_117__Special_Weapons_Adapter__,
+    "{HB_F4E_AGM-65D_LAU117_SWA}": Weapons._Special_Weapons_Adapter__AGM_65D___Maverick_D__IIR_ASM___LAU_117__Special_Weapons_Adapter__,
+    "{HB_BDU-33_SWA}": Weapons._Special_Weapons_Adapter__BDU_33___25lb_Practice_Bomb_LD,
+    "{HB_BDU_45LGB_SWA}": Weapons._Special_Weapons_Adapter__BDU_45_LG___500lb_Practice_Laser_Guided_Bomb,
+    "{HB_BDU-50HD_SWA}": Weapons._Special_Weapons_Adapter__BDU_50HD___500lb_Practice_Bomb_HD,
+    "{HB_BDU-50LD_SWA}": Weapons._Special_Weapons_Adapter__BDU_50LD___500lb_Practice_Bomb_LD,
+    "{HB_CBU-52B_SWA}": Weapons._Special_Weapons_Adapter__CBU_52B___220_x_HE_Frag_bomblets,
+    "{HB_CBU-87_SWA}": Weapons._Special_Weapons_Adapter__CBU_87___202_x_CEM_Cluster_Bomb,
+    "{HB_GBU-12_SWA}": Weapons._Special_Weapons_Adapter__GBU_12___500lb_Laser_Guided_Bomb,
+    "{HB_ROCKEYE_SWA}": Weapons._Special_Weapons_Adapter__Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+    "{HB_MK-81_SWA}": Weapons._Special_Weapons_Adapter__Mk_81___250lb_GP_Bomb_LD,
+    "{HB_MK-82AIR_SWA}": Weapons._Special_Weapons_Adapter__Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+    "{HB_MK-82_Snakeye_SWA}": Weapons._Special_Weapons_Adapter__Mk_82_Snakeye___500lb_GP_Bomb_HD,
+    "{HB_MK-82_SWA}": Weapons._Special_Weapons_Adapter__Mk_82___500lb_GP_Bomb_LD
 }


### PR DESCRIPTION
Pydcs export from May 22 DCS update including Heatblur F4 along with other assets.

See: https://www.digitalcombatsimulator.com/en/news/changelog/