### PR TITLE
add error handling for bad payload files

### DIFF
--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -149,6 +149,11 @@ class FlyingType(UnitType):
             if not payload_dir.exists():
                 continue
             for payload_path in payload_dir.glob("*.lua"):
+                try:
+                    FlyingType._payload_cache[payload_path]
+                except KeyError:
+                    print("Error: Payload file '{f}' not in cache, likely due to a bad lua file".format(f=payload_path))
+                    continue
                 if FlyingType._payload_cache[payload_path] == cls.id and payload_path.exists():
                     try:
                         payload_main = lua.loads(payload_path.read_text(), _globals=FlyingType._UnitPayloadGlobals)

--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import dcs.lua as lua
 from dcs.payloads import PayloadDirectories
+import logging
 import re
 import sys
 from typing import Any, Dict, Iterator, List, Optional, Set, Type, Union, TYPE_CHECKING
@@ -152,7 +153,9 @@ class FlyingType(UnitType):
                 try:
                     FlyingType._payload_cache[payload_path]
                 except KeyError:
-                    print("Error: Payload file '{f}' not in cache, likely due to a bad lua file".format(f=payload_path))
+                    logging.getLogger("pydcs").exception(
+                        "Failed to parse Lua code in %s", payload_path
+                    )
                     continue
                 if FlyingType._payload_cache[payload_path] == cls.id and payload_path.exists():
                     try:


### PR DESCRIPTION
Currently there is a bug where if a payload file doesn't have a unit type it won't get added to the payload cache. Then when load_payloads is called it will try to load the payload file but it won't be in the cache, throwing an [error](https://discord.com/channels/1015931619187621999/1025837223821705236/1342508024845172821). This PR would fix that by bypassing any files that don't get added to the payload cache.